### PR TITLE
[XNIO-96] Allow provider specific properties to be specified and passed i

### DIFF
--- a/api/src/main/java/org/xnio/Options.java
+++ b/api/src/main/java/org/xnio/Options.java
@@ -383,6 +383,11 @@ public final class Options {
     public static final Option<Sequence<String>> SASL_DISALLOWED_MECHANISMS = Option.sequence(Options.class, "SASL_DISALLOWED_MECHANISMS", String.class);
 
     /**
+     * A list of provider specific SASL properties.
+     */
+    public static final Option<Sequence<Property>> SASL_PROPERTIES = Option.sequence(Options.class, "SASL_PROPERTIES", Property.class);
+
+    /**
      * The file access mode to use when opening a file.
      */
     public static final Option<FileAccess> FILE_ACCESS = Option.simple(Options.class, "FILE_ACCESS", FileAccess.class);

--- a/api/src/main/java/org/xnio/Property.java
+++ b/api/src/main/java/org/xnio/Property.java
@@ -1,0 +1,112 @@
+/*
+ * JBoss, Home of Professional Open Source
+ * Copyright 2011, JBoss Inc., and individual contributors as indicated
+ * by the @authors tag. See the copyright.txt in the distribution for a
+ * full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+
+package org.xnio;
+
+import java.io.Serializable;
+
+/**
+ * An immutable property represented by a key and value.
+ *
+ * @author <a href="mailto:darran.lofthouse@jboss.com">Darran Lofthouse</a>
+ */
+public final class Property implements Serializable {
+
+    private static final long serialVersionUID = -4958518978461712277L;
+
+    private final String key;
+    private final String value;
+    private final int hashCode;
+
+    private Property(final String key, final String value) {
+        if (key == null)
+            throw new IllegalArgumentException("key must not be null.");
+
+        if (value == null)
+            throw new IllegalArgumentException("value must not be null.");
+
+        this.key = key;
+        this.value = value;
+        hashCode = key.hashCode() * 7 + value.hashCode();
+    }
+
+    /**
+     * Get the key of this key/value Property.
+     *
+     * @return the key.
+     */
+    public String getKey() {
+        return key;
+    }
+
+    /**
+     * Get the value of this key/value Property.
+     *
+     * @return the value.
+     */
+    public String getValue() {
+        return value;
+    }
+
+    /**
+     * Get the hash code for this Property.
+     *
+     * @return the hash code.
+     */
+    @Override
+    public int hashCode() {
+        return hashCode;
+    }
+
+    /**
+     * Determine if this Property equals another Property.
+     *
+     * @param obj the other Property to compare.
+     * @return true if the two Properties are equal.
+     */
+    @Override
+    public boolean equals(Object obj) {
+        return obj instanceof Property && equals((Property) obj);
+    }
+
+    /**
+     * Determine if this Property equals another Property.
+     *
+     * @param other the other Property to compare.
+     * @return true if the two Properties are equal.
+     */
+    public boolean equals(Property other) {
+        return key.equals(other.key) && value.equals(other.value);
+    }
+
+    /**
+     * Create a new property for the specified key and value.
+     *
+     * @param key   the key for new Property
+     * @param value the value for the new Property
+     * @return the newly created Property
+     */
+    public static Property of(final String key, final String value) {
+        return new Property(key, value);
+    }
+
+}

--- a/api/src/main/java/org/xnio/sasl/SaslUtils.java
+++ b/api/src/main/java/org/xnio/sasl/SaslUtils.java
@@ -31,6 +31,7 @@ import org.xnio.Buffers;
 import org.xnio.Option;
 import org.xnio.OptionMap;
 import org.xnio.Options;
+import org.xnio.Property;
 import org.xnio.Sequence;
 
 import javax.security.sasl.Sasl;
@@ -247,6 +248,7 @@ public final class SaslUtils {
         add(optionMap, Options.SASL_SERVER_AUTH, propertyMap, Sasl.SERVER_AUTH, null);
         addQopList(optionMap, Options.SASL_QOP, propertyMap, Sasl.QOP);
         add(optionMap, Options.SASL_STRENGTH, propertyMap, Sasl.STRENGTH, null);
+        addSaslProperties(optionMap, Options.SASL_PROPERTIES, propertyMap);
         return propertyMap;
     }
 
@@ -270,5 +272,15 @@ public final class SaslUtils {
             }
         } while (iterator.hasNext());
         map.put(propName, builder.toString());
+    }
+
+    private static void addSaslProperties(OptionMap optionMap, Option<Sequence<Property>> option, Map<String, Object> map) {
+        final Sequence<Property> value = optionMap.get(option);
+        if (value == null) return;
+        final Iterator<Property> iterator = value.iterator();
+        while (iterator.hasNext()) {
+            Property current = iterator.next();
+            map.put(current.getKey(), current.getValue());
+        }
     }
 }


### PR DESCRIPTION
[XNIO-96] Allow provider specific properties to be specified and passed into the map created by SaslUtils for the creation of a SaslServer or SaslClient.

(This pull request now has the Property class cleaned up based on the previous comments)
