### PR TITLE
XNIO-195 Make XNIO an OSGi Bundle

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -29,7 +29,7 @@
 
     <groupId>org.jboss.xnio</groupId>
     <artifactId>xnio-api</artifactId>
-    <packaging>jar</packaging>
+    <packaging>bundle</packaging>
     <name>XNIO API</name>
     <description>The API JAR of the XNIO project</description>
     <url>http://www.jboss.org/xnio</url>
@@ -163,6 +163,17 @@
                     </archive>
                 </configuration>
             </plugin>
+            <plugin>
+	        <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Export-Package>
+                          org.xnio.*;version=${project.version};-split-package:=error;-noimport:=true
+                        </Export-Package>
+                    </instructions>
+                </configuration>
+	    </plugin>
             <plugin>
                 <artifactId>maven-source-plugin</artifactId>
             </plugin>

--- a/nio-impl/pom.xml
+++ b/nio-impl/pom.xml
@@ -30,7 +30,7 @@
     <description>The NIO implementation of the XNIO project</description>
     <groupId>org.jboss.xnio</groupId>
     <artifactId>xnio-nio</artifactId>
-    <packaging>jar</packaging>
+    <packaging>bundle</packaging>
 
     <parent>
         <groupId>org.jboss.xnio</groupId>
@@ -71,6 +71,24 @@
             </plugin>
             <plugin>
                 <artifactId>maven-source-plugin</artifactId>
+            </plugin>
+            <plugin>
+	    <groupId>org.apache.felix</groupId>
+            <artifactId>maven-bundle-plugin</artifactId>
+                <configuration>
+                    <instructions>
+                        <Export-Package>
+                            org.xnio.nio;version=${project.version};-split-package:=error;-noimport:=true
+                        </Export-Package>
+                        <Import-Package>
+                            org.xnio.*;version="[${project.version},${project.version}]",
+                            *
+                        </Import-Package>
+                        <Fragment-Host>
+                            org.jboss.xnio.api
+                        </Fragment-Host>
+                    </instructions>
+                </configuration>
             </plugin>
             <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -88,4 +88,31 @@
             </dependency>
         </dependencies>
     </dependencyManagement>
+    
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.felix</groupId>
+                <artifactId>maven-bundle-plugin</artifactId>
+                <version>2.3.7</version>   
+		<extensions>true</extensions>
+                <configuration>
+                    <instructions>
+                        <Bundle-ActivationPolicy>
+                            lazy
+                        </Bundle-ActivationPolicy> 
+                    </instructions>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>bundle-manifest</id>
+                        <phase>process-classes</phase>
+                        <goals>
+                            <goal>manifest</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>


### PR DESCRIPTION
We'd like to use XNIO in an OSGi environment (Equinox). Therefore it
would be convenient if XNIO was already a bundle (or two).

Generally just making a JAR a bundle is not enough to make sure it runs
fine in OSGi. All dynamic class loading has to be analyzed.

I identified the following places where XNIO does dynamic class loading
and believe they are all addressed as I have the XNIO hello world echo
server running in Equinox.
1. `Xnio` uses `ServiceLoader` to dynamically load the implementation
   class. This can be addressed by making xnio-nio a fragment of
   xnio-api.
2. `org.xnio.sasl.SaslUtils#getFactories` already uses the correct
   class loader
3. `org.xnio.Option#fromString` no option classes outside of xnio-api
   seem to be used so this should work
4. `org.xnio.Option#getClassParser` see above
5. `NioXnio` tries to load `java.nio.channels.MulticastChannel` this is
   fine because it's a `java` package which is always available
6. `NioXnio` tries to load `sun.nio.ch.PollSelectorImpl` this is an
   issue as `sun` packages are generally not available. This can be
   solved by setting the `org.osgi.framework.system.packages.extra`
   system property to `sun.nio.ch`

Changes in this pull request:
- make xnio-api a bundle
- make xnio-nio a fragment of xnio-api

Issue: XNIO-195
https://issues.jboss.org/browse/XNIO-195
