### PR TITLE
Changes to allow the use of the Jetty NPN library, to enable SPDY support

### DIFF
--- a/api/src/main/java/org/xnio/ssl/JsseSslConduitEngine.java
+++ b/api/src/main/java/org/xnio/ssl/JsseSslConduitEngine.java
@@ -1031,6 +1031,10 @@ final class JsseSslConduitEngine {
         }
     }
 
+    SSLEngine getEngine() {
+        return engine;
+    }
+
     public boolean isFirstHandshake() {
         return allAreSet(state, FIRST_HANDSHAKE);
     }

--- a/api/src/main/java/org/xnio/ssl/JsseSslStreamConnection.java
+++ b/api/src/main/java/org/xnio/ssl/JsseSslStreamConnection.java
@@ -40,7 +40,7 @@ import org.xnio.conduits.StreamSourceConduit;
  * @author <a href="mailto:frainone@redhat.com">Flavia Rainone</a>
  *
  */
-final class JsseSslStreamConnection extends SslConnection {
+public final class JsseSslStreamConnection extends SslConnection {
 
     /**
      * Delegate connection.
@@ -58,7 +58,6 @@ final class JsseSslStreamConnection extends SslConnection {
      * Callback for notification of a handshake being finished.
      */
     private final ChannelListener.SimpleSetter<SslConnection> handshakeSetter = new ChannelListener.SimpleSetter<SslConnection>();
-
 
     JsseSslStreamConnection(StreamConnection connection, SSLEngine sslEngine, final Pool<ByteBuffer> socketBufferPool, final Pool<ByteBuffer> applicationBufferPool, final boolean startTls) {
         super(connection.getIoThread());
@@ -152,4 +151,9 @@ final class JsseSslStreamConnection extends SslConnection {
         }
         ChannelListeners.<SslConnection>invokeChannelListener(this, listener);
     }
+
+    public SSLEngine getSslEngine() {
+        return sslConduitEngine.getEngine();
+    }
+
 }


### PR DESCRIPTION
The second commit is not essential, but makes things a bit cleaner, and removes the need for hacks such as weak hash maps to store the negotiated next protocol. 
