### PR TITLE
Fixes usages of String#toLowerCase() without a Locale.

### DIFF
--- a/api/src/main/java/org/xnio/http/HttpUpgrade.java
+++ b/api/src/main/java/org/xnio/http/HttpUpgrade.java
@@ -25,6 +25,7 @@ import java.net.InetSocketAddress;
 import java.net.URI;
 import java.nio.ByteBuffer;
 import java.util.HashSet;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 
@@ -186,7 +187,7 @@ public class HttpUpgrade {
                 builder.append(": ");
                 builder.append(header.getValue());
                 builder.append("\r\n");
-                seen.add(header.getKey().toLowerCase());
+                seen.add(header.getKey().toLowerCase(Locale.ENGLISH));
             }
             if (!seen.contains("host")) {
                 builder.append("Host: ");

--- a/api/src/main/java/org/xnio/http/HttpUpgradeParser.java
+++ b/api/src/main/java/org/xnio/http/HttpUpgradeParser.java
@@ -21,6 +21,7 @@ package org.xnio.http;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.HashMap;
+import java.util.Locale;
 import java.util.Map;
 
 /**
@@ -74,7 +75,7 @@ class HttpUpgradeParser {
         while (buffer.hasRemaining()) {
             byte b = buffer.get();
             if (b == '\r' || b == '\n') {
-                headers.put(headerName.toLowerCase(), current.toString().trim());
+                headers.put(headerName.toLowerCase(Locale.ENGLISH), current.toString().trim());
                 parseState--;
                 current.setLength(0);
                 return;


### PR DESCRIPTION
Replaces #toLowerCase() with #toLowerCase(Locale). #toLowerCase() without a Locale may lead to unexpected results in JVM with Turkish locale (s. JavaDocs of String#toLowerCase()).
