### PR TITLE
XNIO-208 Add writeFinal and sendFinal method to channels

### DIFF
--- a/api/src/main/java/org/xnio/channels/AssembledMessageChannel.java
+++ b/api/src/main/java/org/xnio/channels/AssembledMessageChannel.java
@@ -181,6 +181,21 @@ public class AssembledMessageChannel implements MessageChannel {
         return writable.send(buffers, offs, len);
     }
 
+    @Override
+    public boolean sendFinal(ByteBuffer buffer) throws IOException {
+        return writable.sendFinal(buffer);
+    }
+
+    @Override
+    public boolean sendFinal(ByteBuffer[] buffers) throws IOException {
+        return writable.sendFinal(buffers);
+    }
+
+    @Override
+    public boolean sendFinal(ByteBuffer[] buffers, int offs, int len) throws IOException {
+        return writable.sendFinal(buffers, offs, len);
+    }
+
     public boolean flush() throws IOException {
         return writable.flush();
     }

--- a/api/src/main/java/org/xnio/channels/AssembledStreamChannel.java
+++ b/api/src/main/java/org/xnio/channels/AssembledStreamChannel.java
@@ -207,6 +207,21 @@ public class AssembledStreamChannel implements StreamChannel {
         return closeSetter;
     }
 
+    @Override
+    public int writeFinal(ByteBuffer src) throws IOException {
+        return sink.writeFinal(src);
+    }
+
+    @Override
+    public long writeFinal(ByteBuffer[] srcs, int offset, int length) throws IOException {
+        return sink.writeFinal(srcs, offset, length);
+    }
+
+    @Override
+    public long writeFinal(ByteBuffer[] srcs) throws IOException {
+        return sink.writeFinal(srcs);
+    }
+
     public XnioWorker getWorker() {
         return closeable.getWorker();
     }

--- a/api/src/main/java/org/xnio/channels/Channels.java
+++ b/api/src/main/java/org/xnio/channels/Channels.java
@@ -947,6 +947,42 @@ public final class Channels {
         }
     }
 
+    /**
+     * Writes out the data in the buffer to the channel. If all the data is written out
+     * then the channel will have its writes shutdown.
+     *
+     * @param channel The channel
+     * @param src The buffer
+     * @return The number of bytes written
+     * @throws IOException
+     */
+    public static int writeFinalBasic(StreamSinkChannel channel, ByteBuffer src) throws IOException {
+        int res = channel.write(src);
+        if(!src.hasRemaining()) {
+            channel.shutdownWrites();
+        }
+        return res;
+    }
+
+    /**
+     * Writes out the data in the buffer to the channel. If all the data is written out
+     * then the channel will have its writes shutdown.
+     *
+     * @param channel The channel
+     * @param srcs The buffers
+     * @param offset The offset into the srcs array
+     * @param length The number buffers to write
+     * @return The number of bytes written
+     * @throws IOException
+     */
+    public static long writeFinalBasic(StreamSinkChannel channel, ByteBuffer[] srcs, int offset, int length) throws IOException {
+        final long res = channel.write(srcs, offset, length);
+        if (!Buffers.hasRemaining(srcs, offset, length)) {
+            channel.shutdownWrites();
+        }
+        return res;
+    }
+
     static {
         NULL_FILE_CHANNEL = AccessController.doPrivileged(new PrivilegedAction<FileChannel>() {
             public FileChannel run() {

--- a/api/src/main/java/org/xnio/channels/FramedMessageChannel.java
+++ b/api/src/main/java/org/xnio/channels/FramedMessageChannel.java
@@ -273,6 +273,33 @@ public class FramedMessageChannel extends TranslatingSuspendableChannel<Connecte
         }
     }
 
+    @Override
+    public boolean sendFinal(ByteBuffer buffer) throws IOException {
+        if(send(buffer)) {
+            shutdownWrites();
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean sendFinal(ByteBuffer[] buffers) throws IOException {
+        if(send(buffers)) {
+            shutdownWrites();
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean sendFinal(ByteBuffer[] buffers, int offs, int len) throws IOException {
+        if(send(buffers, offs, len)) {
+            shutdownWrites();
+            return true;
+        }
+        return false;
+    }
+
     protected boolean flushAction(final boolean shutDown) throws IOException {
         synchronized (transmitBuffer) {
             return (doFlushBuffer()) && channel.flush();

--- a/api/src/main/java/org/xnio/channels/NullStreamSinkChannel.java
+++ b/api/src/main/java/org/xnio/channels/NullStreamSinkChannel.java
@@ -119,6 +119,21 @@ public final class NullStreamSinkChannel implements StreamSinkChannel, WriteList
         return new CloseListenerSettable.Setter<NullStreamSinkChannel>(this) ;
     }
 
+    @Override
+    public int writeFinal(ByteBuffer src) throws IOException {
+        return Channels.writeFinalBasic(this, src);
+    }
+
+    @Override
+    public long writeFinal(ByteBuffer[] srcs, int offset, int length) throws IOException {
+        return Channels.writeFinalBasic(this, srcs, offset, length);
+    }
+
+    @Override
+    public long writeFinal(ByteBuffer[] srcs) throws IOException {
+        return Channels.writeFinalBasic(this, srcs, 0, srcs.length);
+    }
+
     public int write(final ByteBuffer src) throws IOException {
         int val = enterWrite();
         try {

--- a/api/src/main/java/org/xnio/channels/SplitStreamSinkChannel.java
+++ b/api/src/main/java/org/xnio/channels/SplitStreamSinkChannel.java
@@ -96,6 +96,21 @@ public final class SplitStreamSinkChannel implements StreamSinkChannel, WriteLis
         return new CloseListenerSettable.Setter<SplitStreamSinkChannel>(this);
     }
 
+    @Override
+    public int writeFinal(ByteBuffer src) throws IOException {
+        return delegate.writeFinal(src);
+    }
+
+    @Override
+    public long writeFinal(ByteBuffer[] srcs, int offset, int length) throws IOException {
+        return delegate.writeFinal(srcs, offset, length);
+    }
+
+    @Override
+    public long writeFinal(ByteBuffer[] srcs) throws IOException {
+        return delegate.writeFinal(srcs);
+    }
+
     public ChannelListener.Setter<? extends SplitStreamSinkChannel> getWriteSetter() {
         return new WriteListenerSettable.Setter<SplitStreamSinkChannel>(this);
     }

--- a/api/src/main/java/org/xnio/channels/StreamSinkChannel.java
+++ b/api/src/main/java/org/xnio/channels/StreamSinkChannel.java
@@ -74,4 +74,76 @@ public interface StreamSinkChannel extends WritableByteChannel, GatheringByteCha
 
     /** {@inheritDoc} */
     ChannelListener.Setter<? extends StreamSinkChannel> getCloseSetter();
+
+    /**
+     *
+     * Writes some data to the channel, with the same semantics as
+     * {@link #write(java.nio.ByteBuffer)}. If all the data is written
+     * out then the channel will have its writes shutdown. Semantically this
+     * method is equivalent to:
+     * <code>
+     *     int rem = src.remaining();
+     *     int written = channel.write(src);
+     *     if(written == rem) {
+     *         channel.shutdownWrites()
+     *     }
+     * </code>
+     *
+     * If an exception is thrown the caller is still responsible for closing the channel.
+     *
+     * @see WritableByteChannel#write(java.nio.ByteBuffer)
+     * @see SuspendableWriteChannel#shutdownWrites()
+     * @param src The data to write
+     * @return The amount of data that was actually written.
+     */
+    public int writeFinal(ByteBuffer src) throws IOException;
+
+    /**
+     *
+     * Writes some data to the channel, with the same semantics as
+     * {@link #write(java.nio.ByteBuffer[], int, int)}. If all the data is written
+     * out then the channel will have its writes shutdown.
+     *
+     * If an exception is thrown the caller is still responsible for closing the channel.
+     *
+     * @see GatheringByteChannel#write(java.nio.ByteBuffer[], int, int)
+     *
+     * @see SuspendableWriteChannel#shutdownWrites()
+     *
+     * @param  srcs
+     *         The buffers from which bytes are to be retrieved
+     *
+     * @param  offset
+     *         The offset within the buffer array of the first buffer from
+     *         which bytes are to be retrieved; must be non-negative and no
+     *         larger than <tt>srcs.length</tt>
+     *
+     * @param  length
+     *         The maximum number of buffers to be accessed; must be
+     *         non-negative and no larger than
+     *         <tt>srcs.length</tt>&nbsp;-&nbsp;<tt>offset</tt>
+     *
+     * @return The amount of data that was actually written
+     */
+    public long writeFinal(ByteBuffer[] srcs, int offset, int length)
+            throws IOException;
+
+    /**
+     *
+     * Writes some data to the channel, with the same semantics as
+     * {@link #write(java.nio.ByteBuffer[])}. If all the data is written
+     * out then the channel will have its writes shutdown.
+     *
+     * If an exception is thrown the caller is still responsible for closing the channel.
+     *
+     * @see GatheringByteChannel#write(java.nio.ByteBuffer[])
+     *
+     * @see SuspendableWriteChannel#shutdownWrites()
+     *
+     * @param  srcs
+     *         The buffers from which bytes are to be retrieved
+     *
+     * @return The amount of data that was actually written
+     */
+    public long writeFinal(ByteBuffer[] srcs) throws IOException;
 }

--- a/api/src/main/java/org/xnio/channels/WritableMessageChannel.java
+++ b/api/src/main/java/org/xnio/channels/WritableMessageChannel.java
@@ -55,6 +55,35 @@ public interface WritableMessageChannel extends SuspendableWriteChannel, Configu
      */
     boolean send(ByteBuffer[] buffers, int offs, int len) throws IOException;
 
+    /**
+     * Send a complete message. If the message was successfully sent the channel with have its writes shutdown.
+     *
+     * @param buffer the message to send
+     * @return the result of the send operation; {@code true} if the message was sent, or {@code false} if it would block
+     * @throws IOException if an I/O error occurs
+     */
+    boolean sendFinal(ByteBuffer buffer) throws IOException;
+
+    /**
+     * Send a complete message. If the message was successfully sent the channel with have its writes shutdown.
+     *
+     * @param buffers the buffers holding the message to send
+     * @return the result of the send operation; {@code true} if the message was sent, or {@code false} if it would block
+     * @throws IOException if an I/O error occurs
+     */
+    boolean sendFinal(ByteBuffer[] buffers) throws IOException;
+
+    /**
+     * Send a complete message. If the message was successfully sent the channel with have its writes shutdown.
+     *
+     * @param buffers the buffers holding the message to send
+     * @param offs the offset into the buffer array of the first buffer
+     * @param len the number of buffers that contain data to send
+     * @return the result of the send operation; {@code true} if the message was sent, or {@code false} if it would block
+     * @throws IOException if an I/O error occurs
+     */
+    boolean sendFinal(ByteBuffer[] buffers, int offs, int len) throws IOException;
+
     /** {@inheritDoc} */
     ChannelListener.Setter<? extends WritableMessageChannel> getWriteSetter();
 

--- a/api/src/main/java/org/xnio/conduits/AbstractMessageSinkConduit.java
+++ b/api/src/main/java/org/xnio/conduits/AbstractMessageSinkConduit.java
@@ -44,4 +44,14 @@ public abstract class AbstractMessageSinkConduit<D extends MessageSinkConduit> e
     public boolean send(final ByteBuffer[] srcs, final int offs, final int len) throws IOException {
         return next.send(srcs, offs, len);
     }
+
+    @Override
+    public boolean sendFinal(ByteBuffer[] srcs, int offs, int len) throws IOException {
+        return next.sendFinal(srcs, offs, len);
+    }
+
+    @Override
+    public boolean sendFinal(ByteBuffer src) throws IOException {
+        return next.sendFinal(src);
+    }
 }

--- a/api/src/main/java/org/xnio/conduits/AbstractStreamSinkConduit.java
+++ b/api/src/main/java/org/xnio/conduits/AbstractStreamSinkConduit.java
@@ -54,4 +54,14 @@ public abstract class AbstractStreamSinkConduit<D extends StreamSinkConduit> ext
     public long write(final ByteBuffer[] srcs, final int offs, final int len) throws IOException {
         return next.write(srcs, offs, len);
     }
+
+    @Override
+    public int writeFinal(ByteBuffer src) throws IOException {
+        return next.writeFinal(src);
+    }
+
+    @Override
+    public long writeFinal(ByteBuffer[] srcs, int offset, int length) throws IOException {
+        return next.writeFinal(srcs, offset, length);
+    }
 }

--- a/api/src/main/java/org/xnio/conduits/BufferedStreamSinkConduit.java
+++ b/api/src/main/java/org/xnio/conduits/BufferedStreamSinkConduit.java
@@ -170,6 +170,18 @@ public final class BufferedStreamSinkConduit extends AbstractStreamSinkConduit<S
         }
     }
 
+    @Override
+    public int writeFinal(ByteBuffer src) throws IOException {
+        //todo: non-naive implementations of this
+        return Conduits.writeFinalBasic(this, src);
+    }
+
+    @Override
+    public long writeFinal(ByteBuffer[] srcs, int offset, int length) throws IOException {
+        //todo: non-naive implementations of this
+        return Conduits.writeFinalBasic(this, srcs, offset, length);
+    }
+
     public boolean flush() throws IOException {
         return flushLocal() && super.flush();
     }

--- a/api/src/main/java/org/xnio/conduits/ConduitStreamSinkChannel.java
+++ b/api/src/main/java/org/xnio/conduits/ConduitStreamSinkChannel.java
@@ -99,6 +99,21 @@ public final class ConduitStreamSinkChannel implements StreamSinkChannel, WriteL
         return new CloseListenerSettable.Setter<ConduitStreamSinkChannel>(this);
     }
 
+    @Override
+    public int writeFinal(ByteBuffer src) throws IOException {
+        return conduit.writeFinal(src);
+    }
+
+    @Override
+    public long writeFinal(ByteBuffer[] srcs, int offset, int length) throws IOException {
+        return conduit.writeFinal(srcs, offset, length);
+    }
+
+    @Override
+    public long writeFinal(ByteBuffer[] srcs) throws IOException {
+        return conduit.writeFinal(srcs, 0, srcs.length);
+    }
+
     public void suspendWrites() {
         conduit.suspendWrites();
     }

--- a/api/src/main/java/org/xnio/conduits/ConduitWritableMessageChannel.java
+++ b/api/src/main/java/org/xnio/conduits/ConduitWritableMessageChannel.java
@@ -133,6 +133,21 @@ public final class ConduitWritableMessageChannel implements WritableMessageChann
         return conduit.send(dsts, offs, len);
     }
 
+    @Override
+    public boolean sendFinal(ByteBuffer buffer) throws IOException {
+        return conduit.sendFinal(buffer);
+    }
+
+    @Override
+    public boolean sendFinal(ByteBuffer[] buffers) throws IOException {
+        return conduit.sendFinal(buffers, 0, buffers.length);
+    }
+
+    @Override
+    public boolean sendFinal(ByteBuffer[] buffers, int offs, int len) throws IOException {
+        return conduit.sendFinal(buffers, offs, len);
+    }
+
     public boolean flush() throws IOException {
         return conduit.flush();
     }

--- a/api/src/main/java/org/xnio/conduits/Conduits.java
+++ b/api/src/main/java/org/xnio/conduits/Conduits.java
@@ -18,6 +18,8 @@
 
 package org.xnio.conduits;
 
+import org.xnio.Buffers;
+
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ReadableByteChannel;
@@ -110,5 +112,67 @@ public final class Conduits {
             total += res;
         }
         return total;
+    }
+
+    /**
+     * Writes the buffer to the conduit, and terminates writes if all the data is written
+     * @param conduit The conduit to write to
+     * @param src The data to write
+     * @return The number of bytes written
+     * @throws IOException
+     */
+    public static int writeFinalBasic(StreamSinkConduit conduit, ByteBuffer src) throws IOException {
+        int res = conduit.write(src);
+        if(!src.hasRemaining()) {
+            conduit.terminateWrites();
+        }
+        return res;
+    }
+
+    /**
+     * Writes the buffer to the conduit, and terminates writes if all the data is written
+     * @param conduit The conduit to write to
+     * @param srcs The data to write
+     * @param offset The offset into the data array
+     * @param length The number of buffers to write
+     * @return The number of bytes written
+     * @throws IOException
+     */
+    public static long writeFinalBasic(StreamSinkConduit conduit, ByteBuffer[] srcs, int offset, int length) throws IOException {
+        final long res = conduit.write(srcs, offset, length);
+        if (!Buffers.hasRemaining(srcs, offset, length)) {
+            conduit.terminateWrites();
+        }
+        return res;
+    }
+
+    /**
+     * Writes a message to the conduit, and terminates writes if the send was successfully.
+     * @param conduit The conduit
+     * @param src The message buffer
+     * @return <code>true</code> if the message was sent successfully
+     */
+    public static boolean sendFinalBasic(MessageSinkConduit conduit, ByteBuffer src) throws IOException {
+        if(conduit.send(src)) {
+            conduit.terminateWrites();
+            return true;
+        }
+        return false;
+    }
+
+    /**
+     * Writes a message to the conduit, and terminates writes if the send was successfully.
+     * @param conduit The conduit
+     * @param srcs The message buffers
+     * @param offset The offset in the message buffers
+     * @param length The number of buffers to send
+     * @return <code>true</code> if the message was sent successfully
+     */
+    public static boolean sendFinalBasic(MessageSinkConduit conduit, ByteBuffer[] srcs, int offset, int length) throws IOException {
+        if(conduit.send(srcs, offset, length)) {
+            conduit.terminateWrites();
+            return true;
+        }
+        return false;
     }
 }

--- a/api/src/main/java/org/xnio/conduits/DeflatingStreamSinkConduit.java
+++ b/api/src/main/java/org/xnio/conduits/DeflatingStreamSinkConduit.java
@@ -190,6 +190,18 @@ public final class DeflatingStreamSinkConduit extends AbstractStreamSinkConduit<
         }
     }
 
+    @Override
+    public int writeFinal(ByteBuffer src) throws IOException {
+        //todo: non-naive implementations of this
+        return Conduits.writeFinalBasic(this, src);
+    }
+
+    @Override
+    public long writeFinal(ByteBuffer[] srcs, int offset, int length) throws IOException {
+        //todo: non-naive implementations of this
+        return Conduits.writeFinalBasic(this, srcs, offset, length);
+    }
+
     public void terminateWrites() throws IOException {
         deflater.finish();
     }

--- a/api/src/main/java/org/xnio/conduits/FramingMessageSinkConduit.java
+++ b/api/src/main/java/org/xnio/conduits/FramingMessageSinkConduit.java
@@ -28,6 +28,8 @@ import org.xnio.Pooled;
 /**
  * A message sink conduit which implements a simple message framing protocol over a stream conduit.
  *
+ *
+ *
  * @author <a href="mailto:david.lloyd@redhat.com">David M. Lloyd</a>
  */
 public final class FramingMessageSinkConduit extends AbstractSinkConduit<StreamSinkConduit> implements MessageSinkConduit {
@@ -49,7 +51,7 @@ public final class FramingMessageSinkConduit extends AbstractSinkConduit<StreamS
     }
 
     public boolean send(final ByteBuffer src) throws IOException {
-        final ByteBuffer buffer = transmitBuffer.getResource();
+        final ByteBuffer buffer = src;
         if (!buffer.hasRemaining()) {
             // no zero messages
             return false;
@@ -98,6 +100,17 @@ public final class FramingMessageSinkConduit extends AbstractSinkConduit<StreamS
         Buffers.copy(transmitBuffer, srcs, offs, len);
         writeBuffer();
         return true;
+    }
+
+    @Override
+    public boolean sendFinal(ByteBuffer src) throws IOException {
+        //TODO: non-naive implementation
+        return Conduits.sendFinalBasic(this, src);
+    }
+
+    @Override
+    public boolean sendFinal(ByteBuffer[] srcs, int offs, int len) throws IOException {
+        return Conduits.sendFinalBasic(this, srcs, offs, len);
     }
 
     private boolean writeBuffer() throws IOException {

--- a/api/src/main/java/org/xnio/conduits/MessageSinkConduit.java
+++ b/api/src/main/java/org/xnio/conduits/MessageSinkConduit.java
@@ -31,7 +31,7 @@ public interface MessageSinkConduit extends SinkConduit {
     /**
      * Send a complete message.
      *
-     * @param buffer the message to send
+     * @param src the message to send
      * @return the result of the send operation; {@code true} if the message was sent, or {@code false} if it would block
      * @throws IOException if an I/O error occurs
      */
@@ -40,11 +40,32 @@ public interface MessageSinkConduit extends SinkConduit {
     /**
      * Send a complete message.
      *
-     * @param buffers the buffers holding the message to send
+     * @param srcs the buffers holding the message to send
      * @param offs the offset into the buffer array of the first buffer
      * @param len the number of buffers that contain data to send
      * @return the result of the send operation; {@code true} if the message was sent, or {@code false} if it would block
      * @throws IOException if an I/O error occurs
      */
     boolean send(ByteBuffer[] srcs, int offs, int len) throws IOException;
+
+
+    /**
+     * Send a complete message. If the message is successfully sent then the sink will have its writes terminated.
+     *
+     * @param src the message to send
+     * @return the result of the send operation; {@code true} if the message was sent, or {@code false} if it would block
+     * @throws IOException if an I/O error occurs
+     */
+    boolean sendFinal(ByteBuffer src) throws IOException;
+
+    /**
+     * Send a complete message. If the message is successfully sent then the sink will have its writes terminated.
+     *
+     * @param srcs the buffers holding the message to send
+     * @param offs the offset into the buffer array of the first buffer
+     * @param len the number of buffers that contain data to send
+     * @return the result of the send operation; {@code true} if the message was sent, or {@code false} if it would block
+     * @throws IOException if an I/O error occurs
+     */
+    boolean sendFinal(ByteBuffer[] srcs, int offs, int len) throws IOException;
 }

--- a/api/src/main/java/org/xnio/conduits/MessageStreamSinkConduit.java
+++ b/api/src/main/java/org/xnio/conduits/MessageStreamSinkConduit.java
@@ -57,4 +57,14 @@ public final class MessageStreamSinkConduit extends AbstractSinkConduit<MessageS
         final long remaining = Buffers.remaining(srcs, offs, len);
         return next.send(srcs, offs, len) ? remaining : 0L;
     }
+
+    @Override
+    public int writeFinal(ByteBuffer src) throws IOException {
+        return Conduits.writeFinalBasic(this, src);
+    }
+
+    @Override
+    public long writeFinal(ByteBuffer[] srcs, int offset, int length) throws IOException {
+        return Conduits.writeFinalBasic(this, srcs, offset, length);
+    }
 }

--- a/api/src/main/java/org/xnio/conduits/NullStreamSinkConduit.java
+++ b/api/src/main/java/org/xnio/conduits/NullStreamSinkConduit.java
@@ -22,7 +22,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.util.concurrent.TimeUnit;
-import org.xnio.Option;
+
 import org.xnio.XnioIoThread;
 import org.xnio.XnioWorker;
 import org.xnio.channels.Channels;
@@ -73,6 +73,16 @@ public final class NullStreamSinkConduit implements StreamSinkConduit {
             t += write(srcs[i + offs]);
         }
         return t;
+    }
+
+    @Override
+    public int writeFinal(ByteBuffer src) throws IOException {
+        return Conduits.writeFinalBasic(this, src);
+    }
+
+    @Override
+    public long writeFinal(ByteBuffer[] srcs, int offset, int length) throws IOException {
+        return Conduits.writeFinalBasic(this, srcs, offset, length);
     }
 
     public boolean flush() throws IOException {

--- a/api/src/main/java/org/xnio/conduits/StreamSinkChannelWrappingConduit.java
+++ b/api/src/main/java/org/xnio/conduits/StreamSinkChannelWrappingConduit.java
@@ -61,6 +61,16 @@ public final class StreamSinkChannelWrappingConduit implements StreamSinkConduit
         return channel.write(srcs, offs, len);
     }
 
+    @Override
+    public int writeFinal(ByteBuffer src) throws IOException {
+        return channel.writeFinal(src);
+    }
+
+    @Override
+    public long writeFinal(ByteBuffer[] srcs, int offset, int length) throws IOException {
+        return channel.writeFinal(srcs, offset, length);
+    }
+
     public void terminateWrites() throws IOException {
         channel.shutdownWrites();
     }

--- a/api/src/main/java/org/xnio/conduits/StreamSinkConduit.java
+++ b/api/src/main/java/org/xnio/conduits/StreamSinkConduit.java
@@ -77,4 +77,49 @@ public interface StreamSinkConduit extends SinkConduit {
      * @throws IOException if an error occurs
      */
     long write(ByteBuffer[] srcs, int offs, int len) throws IOException;
+
+
+    /**
+     *
+     * Writes some data to the conduit, with the same semantics as
+     * {@link #write(java.nio.ByteBuffer)}. If all the data is written
+     * out then the conduit will have its writes terminated. Semantically this
+     * method is equivalent to:
+     *
+     * <code>
+     *     int rem = src.remaining();
+     *     int written = conduit.write(src);
+     *     if(written == rem) {
+     *         conduit.terminateWrites()
+     *     }
+     * </code>
+     *
+     * @param src The data to write
+     * @return The amount of data that was actually written.
+     */
+    public int writeFinal(ByteBuffer src) throws IOException;
+
+    /**
+     *
+     * Writes some data to the conduit, with the same semantics as
+     * {@link #write(java.nio.ByteBuffer[], int, int)}. If all the data is written
+     * out then the conduit will have its writes terminated.
+     *
+     *
+     * @param  srcs
+     *         The buffers from which bytes are to be retrieved
+     *
+     * @param  offset
+     *         The offset within the buffer array of the first buffer from
+     *         which bytes are to be retrieved; must be non-negative and no
+     *         larger than <tt>srcs.length</tt>
+     *
+     * @param  length
+     *         The maximum number of buffers to be accessed; must be
+     *         non-negative and no larger than
+     *         <tt>srcs.length</tt>&nbsp;-&nbsp;<tt>offset</tt>
+     *
+     * @return The amount of data that was actually written
+     */
+    public long writeFinal(ByteBuffer[] srcs, int offset, int length) throws IOException;
 }

--- a/api/src/main/java/org/xnio/sasl/SaslUnwrappingConduit.java
+++ b/api/src/main/java/org/xnio/sasl/SaslUnwrappingConduit.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import org.xnio.Buffers;
 import org.xnio.conduits.AbstractMessageSinkConduit;
+import org.xnio.conduits.Conduits;
 import org.xnio.conduits.MessageSinkConduit;
 
 /**
@@ -57,6 +58,16 @@ public final class SaslUnwrappingConduit extends AbstractMessageSinkConduit<Mess
             this.buffer = wrapped;
         }
         return true;
+    }
+
+    @Override
+    public boolean sendFinal(ByteBuffer src) throws IOException {
+        return Conduits.sendFinalBasic(this, src);
+    }
+
+    @Override
+    public boolean sendFinal(ByteBuffer[] srcs, int offs, int len) throws IOException {
+        return Conduits.sendFinalBasic(this, srcs, offs, len);
     }
 
     private boolean doSend() throws IOException {

--- a/api/src/main/java/org/xnio/sasl/SaslWrappingConduit.java
+++ b/api/src/main/java/org/xnio/sasl/SaslWrappingConduit.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import org.xnio.Buffers;
 import org.xnio.conduits.AbstractMessageSinkConduit;
+import org.xnio.conduits.Conduits;
 import org.xnio.conduits.MessageSinkConduit;
 
 /**
@@ -56,6 +57,16 @@ public final class SaslWrappingConduit extends AbstractMessageSinkConduit<Messag
             this.buffer = wrapped;
         }
         return true;
+    }
+
+    @Override
+    public boolean sendFinal(ByteBuffer src) throws IOException {
+        return Conduits.sendFinalBasic(this, src);
+    }
+
+    @Override
+    public boolean sendFinal(ByteBuffer[] srcs, int offs, int len) throws IOException {
+        return Conduits.sendFinalBasic(this, srcs, offs, len);
     }
 
     private boolean doSend() throws IOException {

--- a/api/src/test/java/org/xnio/mock/ConduitMock.java
+++ b/api/src/test/java/org/xnio/mock/ConduitMock.java
@@ -36,6 +36,7 @@ import org.xnio.XnioWorker;
 import org.xnio.channels.AssembledConnectedStreamChannel;
 import org.xnio.channels.StreamSinkChannel;
 import org.xnio.channels.StreamSourceChannel;
+import org.xnio.conduits.Conduits;
 import org.xnio.conduits.ReadReadyHandler;
 import org.xnio.conduits.StreamSinkConduit;
 import org.xnio.conduits.StreamSourceConduit;
@@ -698,6 +699,16 @@ public class ConduitMock implements StreamSinkConduit, StreamSourceConduit, Mock
             return bytes;
         }
         return 0;
+    }
+
+    @Override
+    public int writeFinal(ByteBuffer src) throws IOException {
+        return Conduits.writeFinalBasic(this, src);
+    }
+
+    @Override
+    public long writeFinal(ByteBuffer[] srcs, int offset, int length) throws IOException {
+        return Conduits.writeFinalBasic(this, srcs, offset, length);
     }
 
     @Override

--- a/api/src/test/java/org/xnio/mock/ConnectedStreamChannelMock.java
+++ b/api/src/test/java/org/xnio/mock/ConnectedStreamChannelMock.java
@@ -37,6 +37,7 @@ import org.xnio.OptionMap;
 import org.xnio.XnioExecutor;
 import org.xnio.XnioIoThread;
 import org.xnio.XnioWorker;
+import org.xnio.channels.Channels;
 import org.xnio.channels.ConnectedStreamChannel;
 import org.xnio.channels.StreamSinkChannel;
 import org.xnio.channels.StreamSourceChannel;
@@ -751,6 +752,21 @@ public class ConnectedStreamChannelMock implements ConnectedStreamChannel, Strea
     @Override
     public Setter<? extends ConnectedStreamChannel> getCloseSetter() {
         return closeListenerSetter;
+    }
+
+    @Override
+    public int writeFinal(ByteBuffer src) throws IOException {
+        return Channels.writeFinalBasic(this, src);
+    }
+
+    @Override
+    public long writeFinal(ByteBuffer[] srcs, int offset, int length) throws IOException {
+        return Channels.writeFinalBasic(this, srcs, offset, length);
+    }
+
+    @Override
+    public long writeFinal(ByteBuffer[] srcs) throws IOException {
+        return Channels.writeFinalBasic(this, srcs, 0, srcs.length);
     }
 
     public ChannelListener<? super ConnectedStreamChannel> getReadListener() {

--- a/api/src/test/java/org/xnio/mock/MessageChannelMock.java
+++ b/api/src/test/java/org/xnio/mock/MessageChannelMock.java
@@ -192,6 +192,33 @@ public class MessageChannelMock implements ReadableMessageChannel, WritableMessa
     }
 
     @Override
+    public boolean sendFinal(ByteBuffer buffer) throws IOException {
+        if(send(buffer)) {
+            shutdownWrites();
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean sendFinal(ByteBuffer[] buffers) throws IOException {
+        if(send(buffers)) {
+            shutdownWrites();
+            return true;
+        }
+        return false;
+    }
+
+    @Override
+    public boolean sendFinal(ByteBuffer[] buffers, int offs, int len) throws IOException {
+        if(send(buffers, offs, len)) {
+            shutdownWrites();
+            return true;
+        }
+        return false;
+    }
+
+    @Override
     public Setter<? extends WritableMessageChannel> getWriteSetter() {
         return writeListenerSetter;
     }

--- a/nio-impl/src/main/java/org/xnio/nio/NioPipeSinkConduit.java
+++ b/nio-impl/src/main/java/org/xnio/nio/NioPipeSinkConduit.java
@@ -128,6 +128,16 @@ final class NioPipeSinkConduit extends NioHandle implements StreamSinkConduit {
         return res;
     }
 
+    @Override
+    public int writeFinal(ByteBuffer src) throws IOException {
+        return Conduits.writeFinalBasic(this, src);
+    }
+
+    @Override
+    public long writeFinal(ByteBuffer[] srcs, int offset, int length) throws IOException {
+        return Conduits.writeFinalBasic(this, srcs, offset, length);
+    }
+
     public boolean flush() throws IOException {
         return true;
     }

--- a/nio-impl/src/main/java/org/xnio/nio/NioSocketConduit.java
+++ b/nio-impl/src/main/java/org/xnio/nio/NioSocketConduit.java
@@ -161,6 +161,16 @@ final class NioSocketConduit extends NioHandle implements StreamSourceConduit, S
         return res;
     }
 
+    @Override
+    public int writeFinal(ByteBuffer src) throws IOException {
+        return Conduits.writeFinalBasic(this, src);
+    }
+
+    @Override
+    public long writeFinal(ByteBuffer[] srcs, int offset, int length) throws IOException {
+        return Conduits.writeFinalBasic(this, srcs, offset, length);
+    }
+
     public boolean flush() throws IOException {
         return true;
     }


### PR DESCRIPTION
This allows for optimisation of protocols that require writing
termination data, such as HTTP chunking.
