### PR TITLE
[XNIO-219] Temporarily construct the exception manually until LOGTOOL-78 is fixed.

### DIFF
--- a/api/src/main/java/org/xnio/_private/Messages.java
+++ b/api/src/main/java/org/xnio/_private/Messages.java
@@ -40,7 +40,6 @@ import org.jboss.logging.annotations.Field;
 import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
-import org.jboss.logging.annotations.Param;
 import org.xnio.IoFuture;
 import org.xnio.channels.AcceptingChannel;
 import org.xnio.channels.ConcurrentStreamChannelAccessException;
@@ -49,7 +48,6 @@ import org.xnio.channels.FixedLengthOverflowException;
 import org.xnio.channels.FixedLengthUnderflowException;
 import org.xnio.channels.ReadTimeoutException;
 import org.xnio.channels.WriteTimeoutException;
-import org.xnio.http.RedirectException;
 
 import static org.jboss.logging.Logger.Level.*;
 
@@ -283,7 +281,7 @@ public interface Messages extends BasicLogger {
     // 815 - worker shut down
 
     @Message(id = 816, value = "Redirect encountered establishing connection")
-    RedirectException redirect(@Param int responseCode, @Param String location);
+    String redirect();
 
     // Unsupported implementation operations - cross-check with xnio-nio
 

--- a/api/src/main/java/org/xnio/http/HttpUpgrade.java
+++ b/api/src/main/java/org/xnio/http/HttpUpgrade.java
@@ -362,7 +362,7 @@ public class HttpUpgrade {
 
         private void handleRedirect(final HttpUpgradeParser parser, final StreamSourceChannel channel) {
             IoUtils.safeClose(channel);
-            future.setException(msg.redirect(parser.getResponseCode(), parser.getHeaders().get("location")));
+            future.setException(new RedirectException(msg.redirect(), parser.getResponseCode(), parser.getHeaders().get("location")));
         }
 
     }


### PR DESCRIPTION
This single commit can then be reverted once LOGTOOL-78 is fixed.

Also any chance of an XNIO and Remoting release for WildFly so I can get my remaining changes for HTTP Upgrade over SSL submitted?
