### PR TITLE
XNIO-226 SSL Communication - SSLEngine DNS Reverse Lookup

### DIFF
--- a/api/src/main/java/org/xnio/ssl/AbstractAcceptingSslChannel.java
+++ b/api/src/main/java/org/xnio/ssl/AbstractAcceptingSslChannel.java
@@ -142,7 +142,9 @@ abstract class AbstractAcceptingSslChannel<C extends ConnectedChannel, S extends
             return null;
         }
         final InetSocketAddress peerAddress = tcpConnection.getPeerAddress(InetSocketAddress.class);
-        final SSLEngine engine = sslContext.createSSLEngine(peerAddress.isUnresolved() ? peerAddress.getAddress().getHostAddress() : peerAddress.getHostName(), peerAddress.getPort());
+        //we do this to prevent possible reverse DNS lookup, so we pass host name only in case when client auth is requested
+        final boolean useHostName = AbstractAcceptingSslChannel.this.clientAuthMode == SslClientAuthMode.REQUESTED;
+        final SSLEngine engine = sslContext.createSSLEngine(useHostName ? peerAddress.getAddress().getHostAddress() : peerAddress.getHostName(), peerAddress.getPort());
         final boolean clientMode = useClientMode != 0;
         engine.setUseClientMode(clientMode);
         if (! clientMode) {


### PR DESCRIPTION
Do not use hostname unless client auth is requested
