### PR TITLE
Cleanup pom.xml & update dependencies

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -102,33 +102,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-enforcer-plugin</artifactId>
-                <version>1.0.1</version>
-                <executions>
-                    <execution>
-                        <!-- Enforce Java 7 version -->
-                        <id>enforce-java-7-version</id>
-                        <goals>
-                            <goal>enforce</goal>
-                        </goals>
-                        <configuration>
-                            <skip>${skip.enforcer}</skip>
-                            <rules>
-                                <requireJavaVersion>
-                                    <!-- version >= 1.7 -->
-                                    <version>[1.7,)</version>
-                                    <message>Java 7 or higher required to build this project</message>
-                                </requireJavaVersion>
-                            </rules>
-                        </configuration>
-                    </execution>
-                </executions>
-            </plugin>
-            <plugin>
-                <artifactId>maven-compiler-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <artifactId>maven-jar-plugin</artifactId>
                 <configuration>
                     <excludes>
@@ -146,10 +119,8 @@
                 </configuration>
             </plugin>
             <plugin>
-                <artifactId>maven-source-plugin</artifactId>
-            </plugin>
-            <plugin>
                 <artifactId>maven-surefire-plugin</artifactId>
+                <version>${version.surefire.plugin}</version>
                 <configuration>
                     <systemProperties>
                         <property>
@@ -178,9 +149,9 @@
                     <doctitle><![CDATA[XNIO API ]]>${project.version}</doctitle>
                     <header><![CDATA[XNIO API ]]>${project.version}</header>
                     <footer><![CDATA[XNIO API ]]>${project.version}</footer>
-                    <bottom><![CDATA[<i>Copyright &#169; 2010 JBoss, a division of Red Hat, Inc.</i>]]></bottom>
+                    <bottom><![CDATA[<i>Copyright &#169; 2014 JBoss, a division of Red Hat, Inc.</i>]]></bottom>
                     <links>
-                        <link>http://java.sun.com/javase/6/docs/api/</link>
+                        <link>http://java.sun.com/javase/7/docs/api/</link>
                     </links>
                 </configuration>
             </plugin>

--- a/pom.xml
+++ b/pom.xml
@@ -22,6 +22,11 @@
          xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
     <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>org.jboss</groupId>
+        <artifactId>jboss-parent</artifactId>
+        <version>14</version>
+    </parent>
 
     <groupId>org.jboss.xnio</groupId>
     <artifactId>xnio-all</artifactId>
@@ -36,18 +41,14 @@
     </modules>
 
     <properties>
-        <version.surefire.plugin>2.8</version.surefire.plugin>
-        <byteman-version>2.0.4</byteman-version>
-
-        <!-- tools.jar location, this needs to be overriden on OSX -->
-        <com.sun.tools.path>${java.home}/../lib/tools.jar</com.sun.tools.path>
+        <byteman-version>2.1.4.1</byteman-version>
+        <version.org.jboss.logging.jboss-logging>3.1.4.GA</version.org.jboss.logging.jboss-logging>
+        <version.org.jboss.logging.jboss-logging-tools>1.2.0.Final</version.org.jboss.logging.jboss-logging-tools>
+        <version.org.jboss.logmanager.jboss-logmanager>1.5.2.Final</version.org.jboss.logmanager.jboss-logmanager>
+        <version.surefire.plugin>2.17</version.surefire.plugin>
+        <version.junit>4.11</version.junit>
+        <version.jmock>2.5.1</version.jmock>
     </properties>
-
-    <parent>
-        <groupId>org.jboss</groupId>
-        <artifactId>jboss-parent</artifactId>
-        <version>11</version>
-    </parent>
 
     <dependencyManagement>
         <dependencies>
@@ -70,37 +71,39 @@
             <dependency>
                 <groupId>org.jboss.logging</groupId>
                 <artifactId>jboss-logging</artifactId>
-                <version>3.1.2.GA</version>
+                <version>${version.org.jboss.logging.jboss-logging}</version>
             </dependency>
             <dependency>
                 <groupId>org.jboss.logging</groupId>
                 <artifactId>jboss-logging-processor</artifactId>
-                <version>1.2.0.Beta1</version>
+                <version>${version.org.jboss.logging.jboss-logging-tools}</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.jboss.logging</groupId>
                 <artifactId>jboss-logging-annotations</artifactId>
-                <version>1.2.0.Beta1</version>
+                <version>${version.org.jboss.logging.jboss-logging-tools}</version>
+                <scope>provided</scope>
             </dependency>
             <dependency>
                 <groupId>org.jmock</groupId>
                 <artifactId>jmock</artifactId>
-                <version>2.5.1</version>
+                <version>${version.jmock}</version>
             </dependency>
             <dependency>
                 <groupId>org.jmock</groupId>
                 <artifactId>jmock-junit4</artifactId>
-                <version>2.5.1</version>
+                <version>${version.jmock}</version>
             </dependency>
             <dependency>
                 <groupId>org.jboss.logmanager</groupId>
                 <artifactId>jboss-logmanager</artifactId>
-                <version>1.2.0.GA</version>
+                <version>${version.org.jboss.logmanager.jboss-logmanager}</version>
             </dependency>
             <dependency>
                 <groupId>junit</groupId>
                 <artifactId>junit</artifactId>
-                <version>4.8.2</version>
+                <version>${version.junit}</version>
             </dependency>
             <dependency>
                 <groupId>org.jboss.byteman</groupId>
@@ -126,29 +129,6 @@
                 <version>${byteman-version}</version>
                 <scope>test</scope>
             </dependency>
-            <!-- The dependency is pull in indirectly from byteman -->
-            <!-- We override it here to allow it to work correctly on osx -->
-            <dependency>
-                <groupId>com.sun</groupId>
-                <artifactId>tools</artifactId>
-                <scope>system</scope>
-                <version>1.6</version>
-                <systemPath>${com.sun.tools.path}</systemPath>
-            </dependency>
         </dependencies>
     </dependencyManagement>
-
-    <profiles>
-        <profile>
-            <id>os-x</id>
-            <activation>
-                <file>
-                    <exists>${java.home}/bundle/Classes/classes.jar</exists>
-                </file>
-            </activation>
-            <properties>
-                <com.sun.tools.path>${java.home}/bundle/Classes/classes.jar</com.sun.tools.path>
-            </properties>
-        </profile>
-    </profiles>
 </project>


### PR DESCRIPTION
- byteman upgrade makes it work much better on windows
- remove mac osx jvm hacks, as since jdk7 jvm is the same as on other platforms.

replaces #48
