### PR TITLE
Upgrade JMock to 2.6.0 and use its new functionalities

### DIFF
--- a/api/src/test/java/org/xnio/racecondition/SetReadListenerOnHandlingReadableChannelTestCase.java
+++ b/api/src/test/java/org/xnio/racecondition/SetReadListenerOnHandlingReadableChannelTestCase.java
@@ -27,6 +27,7 @@ import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
 import org.jmock.integration.junit4.JUnit4Mockery;
+import org.jmock.lib.concurrent.Synchroniser;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.xnio.ChannelListener;
@@ -49,7 +50,9 @@ public class SetReadListenerOnHandlingReadableChannelTestCase {
     @Test
     public void test() throws Exception {
         // create mockery context
-        final Mockery context = new JUnit4Mockery();
+        final Mockery context = new JUnit4Mockery() {{
+            setThreadingPolicy(new Synchroniser());
+        }};
         // creating channel and threads
         final MyTranslatingSuspendableChannel channel = new MyTranslatingSuspendableChannel();
         final Thread setReadListenerThread = new Thread(new SetReadListener(channel, context));

--- a/api/src/test/java/org/xnio/racecondition/SetWriteListenerOnHandlingWritableChannelTestCase.java
+++ b/api/src/test/java/org/xnio/racecondition/SetWriteListenerOnHandlingWritableChannelTestCase.java
@@ -27,6 +27,7 @@ import org.jboss.byteman.contrib.bmunit.BMUnitRunner;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
 import org.jmock.integration.junit4.JUnit4Mockery;
+import org.jmock.lib.concurrent.Synchroniser;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.xnio.ChannelListener;
@@ -49,7 +50,9 @@ public class SetWriteListenerOnHandlingWritableChannelTestCase {
     @Test
     public void test() throws Exception {
         // create mockery context
-        final Mockery context = new JUnit4Mockery();
+        final Mockery context = new JUnit4Mockery() {{
+            setThreadingPolicy(new Synchroniser());
+        }};
         // creating channel and threads
         final MyTranslatingSuspendableChannel channel = new MyTranslatingSuspendableChannel();
         final Thread setWriteListenerThread = new Thread(new SetWriteListener(channel, context));

--- a/api/src/test/java/org/xnio/ssl/AbstractSslTest.java
+++ b/api/src/test/java/org/xnio/ssl/AbstractSslTest.java
@@ -25,6 +25,7 @@ import java.nio.ByteBuffer;
 
 import org.jmock.Mockery;
 import org.jmock.integration.junit4.JUnit4Mockery;
+import org.jmock.lib.concurrent.Synchroniser;
 import org.junit.After;
 import org.junit.Before;
 import org.xnio.Buffers;
@@ -47,7 +48,9 @@ public abstract class AbstractSslTest {
 
     @Before
     public void createChannelMock() throws IOException {
-        context = new JUnit4Mockery();
+        context = new JUnit4Mockery() {{
+            setThreadingPolicy(new Synchroniser());
+        }};
         engineMock = new SSLEngineMock(context);
     }
 

--- a/api/src/test/java/org/xnio/ssl/ConnectedSslStreamChannelBufferOverflowTestCase.java
+++ b/api/src/test/java/org/xnio/ssl/ConnectedSslStreamChannelBufferOverflowTestCase.java
@@ -30,6 +30,7 @@ import javax.net.ssl.SSLSession;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
 import org.jmock.integration.junit4.JUnit4Mockery;
+import org.jmock.lib.concurrent.Synchroniser;
 import org.junit.Test;
 import org.xnio.BufferAllocator;
 import org.xnio.ByteBufferSlicePool;
@@ -59,7 +60,9 @@ public class ConnectedSslStreamChannelBufferOverflowTestCase extends AbstractCon
 
     @Override
     protected ConnectedSslStreamChannel createSslChannel() {
-        context = new JUnit4Mockery();
+        context = new JUnit4Mockery() {{
+            setThreadingPolicy(new Synchroniser());
+        }};
         connectedChannelMock = new ConnectedStreamChannelMock();
         engineMock = new SSLEngineMockSmallPacketSize(context);
         final Pool<ByteBuffer> socketBufferPool = new ByteBufferSlicePool(BufferAllocator.BYTE_BUFFER_ALLOCATOR, 10, 160);

--- a/api/src/test/java/org/xnio/ssl/ConnectedSslStreamChannelReadTestCase.java
+++ b/api/src/test/java/org/xnio/ssl/ConnectedSslStreamChannelReadTestCase.java
@@ -37,6 +37,8 @@ import java.nio.ByteBuffer;
 import javax.net.ssl.SSLEngineResult.HandshakeStatus;
 
 import org.jmock.integration.junit4.JMock;
+import org.jmock.integration.junit4.JUnitRuleMockery;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.xnio.ssl.mock.SSLEngineMock;
@@ -47,8 +49,9 @@ import org.xnio.ssl.mock.SSLEngineMock;
  * 
  * @author <a href="mailto:frainone@redhat.com">Flavia Rainone</a>
  */
-@RunWith(JMock.class)
 public class ConnectedSslStreamChannelReadTestCase extends AbstractConnectedSslStreamChannelTest{
+    @Rule
+    public final JUnitRuleMockery context = new JUnitRuleMockery();
 
     @Test
     public void readWithoutHandshake() throws IOException {

--- a/api/src/test/java/org/xnio/ssl/ConnectedSslStreamChannelReadWriteTestCase.java
+++ b/api/src/test/java/org/xnio/ssl/ConnectedSslStreamChannelReadWriteTestCase.java
@@ -20,7 +20,6 @@
 package org.xnio.ssl;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
@@ -42,10 +41,10 @@ import java.util.concurrent.TimeoutException;
 
 import javax.net.ssl.SSLEngineResult.HandshakeStatus;
 
-import org.jmock.integration.junit4.JMock;
-import org.junit.Ignore;
+import org.jmock.integration.junit4.JUnitRuleMockery;
+import org.jmock.lib.concurrent.Synchroniser;
+import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.xnio.Buffers;
 import org.xnio.ssl.mock.SSLEngineMock;
 
@@ -55,9 +54,11 @@ import org.xnio.ssl.mock.SSLEngineMock;
  * 
  * @author <a href="mailto:frainone@redhat.com">Flavia Rainone</a>
  */
-@RunWith(JMock.class)
-@Ignore // ignoring for now as these tests hang more consistently than they pass
 public class ConnectedSslStreamChannelReadWriteTestCase extends AbstractConnectedSslStreamChannelTest{
+    @Rule
+    public final JUnitRuleMockery context = new JUnitRuleMockery() {{
+        setThreadingPolicy(new Synchroniser());
+    }};
 
     @Test
     public void simpleReadAndWrite() throws Exception {

--- a/api/src/test/java/org/xnio/ssl/ConnectedSslStreamChannelWriteTestCase.java
+++ b/api/src/test/java/org/xnio/ssl/ConnectedSslStreamChannelWriteTestCase.java
@@ -38,6 +38,8 @@ import java.nio.ByteBuffer;
 import javax.net.ssl.SSLEngineResult.HandshakeStatus;
 
 import org.jmock.integration.junit4.JMock;
+import org.jmock.integration.junit4.JUnitRuleMockery;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.xnio.ssl.mock.SSLEngineMock;
@@ -48,8 +50,9 @@ import org.xnio.ssl.mock.SSLEngineMock;
  * 
  * @author <a href="mailto:frainone@redhat.com">Flavia Rainone</a>
  */
-@RunWith(JMock.class)
 public class ConnectedSslStreamChannelWriteTestCase extends AbstractConnectedSslStreamChannelTest {
+    @Rule
+    public final JUnitRuleMockery context = new JUnitRuleMockery();
 
     @Test
     public void writeWithoutHandshake() throws IOException {

--- a/api/src/test/java/org/xnio/ssl/JsseSslStreamConnectionBufferOverflowTestCase.java
+++ b/api/src/test/java/org/xnio/ssl/JsseSslStreamConnectionBufferOverflowTestCase.java
@@ -30,6 +30,7 @@ import javax.net.ssl.SSLSession;
 import org.jmock.Expectations;
 import org.jmock.Mockery;
 import org.jmock.integration.junit4.JUnit4Mockery;
+import org.jmock.lib.concurrent.Synchroniser;
 import org.junit.Before;
 import org.junit.Test;
 import org.xnio.BufferAllocator;
@@ -63,7 +64,9 @@ public class JsseSslStreamConnectionBufferOverflowTestCase {
 
     @Before
     public void createChannelMock() throws IOException {
-        context = new JUnit4Mockery();
+        context = new JUnit4Mockery() {{
+                    setThreadingPolicy(new Synchroniser());
+                }};
         engineMock = new SSLEngineMockSmallPacketSize(context);
         final Pool<ByteBuffer> socketBufferPool = new ByteBufferSlicePool(BufferAllocator.BYTE_BUFFER_ALLOCATOR, 10, 160);
         final Pool<ByteBuffer> applicationBufferPool = new ByteBufferSlicePool(BufferAllocator.BYTE_BUFFER_ALLOCATOR, 10, 160);

--- a/api/src/test/java/org/xnio/ssl/JsseSslStreamConnectionTestCase.java
+++ b/api/src/test/java/org/xnio/ssl/JsseSslStreamConnectionTestCase.java
@@ -20,7 +20,6 @@
 package org.xnio.ssl;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertTrue;
@@ -42,10 +41,9 @@ import java.util.concurrent.TimeoutException;
 
 import javax.net.ssl.SSLEngineResult.HandshakeStatus;
 
-import org.jmock.integration.junit4.JMock;
-import org.junit.Ignore;
+import org.jmock.integration.junit4.JUnitRuleMockery;
+import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.xnio.Buffers;
 import org.xnio.ssl.mock.SSLEngineMock;
 
@@ -55,9 +53,9 @@ import org.xnio.ssl.mock.SSLEngineMock;
  * 
  * @author <a href="mailto:frainone@redhat.com">Flavia Rainone</a>
  */
-@RunWith(JMock.class)
-@Ignore // ignoring for now as these tests hang more consistently than they pass
 public class JsseSslStreamConnectionTestCase extends AbstractSslConnectionTest{
+    @Rule
+    public final JUnitRuleMockery context = new JUnitRuleMockery();
 
     @Test
     public void simpleReadAndWrite() throws Exception {

--- a/api/src/test/java/org/xnio/ssl/JsseSslStreamSinkConduitTestCase.java
+++ b/api/src/test/java/org/xnio/ssl/JsseSslStreamSinkConduitTestCase.java
@@ -37,10 +37,9 @@ import java.nio.ByteBuffer;
 
 import javax.net.ssl.SSLEngineResult.HandshakeStatus;
 
-import org.jmock.integration.junit4.JMock;
-import org.junit.Ignore;
+import org.jmock.integration.junit4.JUnitRuleMockery;
+import org.junit.Rule;
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.xnio.ssl.mock.SSLEngineMock;
 
 
@@ -49,9 +48,9 @@ import org.xnio.ssl.mock.SSLEngineMock;
  * 
  * @author <a href="mailto:frainone@redhat.com">Flavia Rainone</a>
  */
-@RunWith(JMock.class)
 public class JsseSslStreamSinkConduitTestCase extends AbstractSslConnectionTest {
-
+    @Rule
+    public final JUnitRuleMockery context = new JUnitRuleMockery();
     @Test
     public void writeWithoutHandshake() throws IOException {
         // no handshake actions for engineMock this time, meaning that it will just wrap and unwrap without any handshake

--- a/api/src/test/java/org/xnio/ssl/JsseSslStreamSourceConduitTestCase.java
+++ b/api/src/test/java/org/xnio/ssl/JsseSslStreamSourceConduitTestCase.java
@@ -37,6 +37,8 @@ import java.nio.ByteBuffer;
 import javax.net.ssl.SSLEngineResult.HandshakeStatus;
 
 import org.jmock.integration.junit4.JMock;
+import org.jmock.integration.junit4.JUnitRuleMockery;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.xnio.ssl.mock.SSLEngineMock;
@@ -47,8 +49,9 @@ import org.xnio.ssl.mock.SSLEngineMock;
  * 
  * @author <a href="mailto:frainone@redhat.com">Flavia Rainone</a>
  */
-@RunWith(JMock.class)
 public class JsseSslStreamSourceConduitTestCase extends AbstractSslConnectionTest{
+    @Rule
+    public final JUnitRuleMockery context = new JUnitRuleMockery();
 
     @Test
     public void readWithoutHandshake() throws IOException {

--- a/pom.xml
+++ b/pom.xml
@@ -47,7 +47,7 @@
         <version.org.jboss.logmanager.jboss-logmanager>1.5.2.Final</version.org.jboss.logmanager.jboss-logmanager>
         <version.surefire.plugin>2.17</version.surefire.plugin>
         <version.junit>4.11</version.junit>
-        <version.jmock>2.5.1</version.jmock>
+        <version.jmock>2.6.0</version.jmock>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
It should prevent often SSL test hangs
