### PR TITLE
Greeting messages should be debug.

### DIFF
--- a/api/src/main/java/org/xnio/_private/Messages.java
+++ b/api/src/main/java/org/xnio/_private/Messages.java
@@ -62,7 +62,7 @@ public interface Messages extends BasicLogger {
     // Greeting
 
     @Message(value = "XNIO version %s")
-    @LogMessage(level = INFO)
+    @LogMessage(level = DEBUG)
     void greeting(String version);
 
     // Validation messages - cross-check with xnio-nio

--- a/nio-impl/src/main/java/org/xnio/nio/Log.java
+++ b/nio-impl/src/main/java/org/xnio/nio/Log.java
@@ -51,7 +51,7 @@ interface Log extends BasicLogger {
 
     // Greeting
 
-    @LogMessage(level = INFO)
+    @LogMessage(level = DEBUG)
     @Message(value = "XNIO NIO Implementation Version %s")
     void greeting(String version);
 


### PR DESCRIPTION
When embedding XNIO (or undertow for that matter), it logs these
versions on every app start which is not only not very useful but
clutters up the logs.
