### PR TITLE
Avoid missleading junit cleanup failures, if tests are aborted.

### DIFF
--- a/nio-impl/src/test/java/org/xnio/nio/test/TcpChannelTestCase.java
+++ b/nio-impl/src/test/java/org/xnio/nio/test/TcpChannelTestCase.java
@@ -45,7 +45,7 @@ import org.xnio.channels.StreamChannel;
 
 /**
  * Tests a pair of connected TCP stream channels (client/server).
- * 
+ *
  * @author <a href="mailto:frainone@redhat.com">Flavia Rainone</a>
  */
 @SuppressWarnings("deprecation")
@@ -67,12 +67,14 @@ public class TcpChannelTestCase extends AbstractNioStreamChannelTest {
 
     @After
     public void closeServer() throws IOException {
-        server.close();
+        if (server != null) {
+            server.close();
+        }
     }
 
     @Override
     protected synchronized void initChannels(XnioWorker xnioWorker, OptionMap optionMap, TestChannelListener<StreamChannel> channelListener,
-            TestChannelListener<StreamChannel> serverChannelListener) throws IOException { 
+            TestChannelListener<StreamChannel> serverChannelListener) throws IOException {
 
         if (channel != null) {
             channel.close();

--- a/nio-impl/src/test/java/org/xnio/nio/test/TcpConnectionTestCase.java
+++ b/nio-impl/src/test/java/org/xnio/nio/test/TcpConnectionTestCase.java
@@ -46,7 +46,7 @@ import org.xnio.channels.StreamSourceChannel;
 
 /**
  * Tests a pair of connected TCP connections (client/server).
- * 
+ *
  * @author <a href="mailto:frainone@redhat.com">Flavia Rainone</a>
  */
 public class TcpConnectionTestCase extends AbstractStreamSinkSourceChannelTest<StreamSinkChannel, StreamSourceChannel> {
@@ -67,12 +67,14 @@ public class TcpConnectionTestCase extends AbstractStreamSinkSourceChannelTest<S
 
     @After
     public void closeServer() throws IOException {
-        server.close();
+        if (server != null) {
+            server.close();
+        }
     }
 
     @Override
     protected synchronized void initChannels(XnioWorker xnioWorker, OptionMap optionMap, TestChannelListener<StreamSinkChannel> channelListener,
-            TestChannelListener<StreamSourceChannel> serverChannelListener) throws IOException { 
+            TestChannelListener<StreamSourceChannel> serverChannelListener) throws IOException {
 
         if (connection != null) {
             connection.close();


### PR DESCRIPTION
This will also delete some trailing space, let me know if you want to not have that in a PR.

I was debugging some test failures, and the additional failures of the @After method confused me a bit. This way the NPE is avoided if the failure is before a server could be instantiated (for example port conflict).
