### PR TITLE
XNIO-235. use doPrivileged() block to shut down executor

### DIFF
--- a/api/src/main/java/org/xnio/XnioWorker.java
+++ b/api/src/main/java/org/xnio/XnioWorker.java
@@ -551,7 +551,12 @@ public abstract class XnioWorker extends AbstractExecutorService implements Conf
      * the {@link #taskPoolTerminated()} method is called.
      */
     protected void shutDownTaskPool() {
-        taskPool.shutdown();
+        doPrivileged(new PrivilegedAction<Object>() {
+            public Object run() {
+                taskPool.shutdown();
+                return null;
+            }
+        });
     }
 
     /**
@@ -560,7 +565,11 @@ public abstract class XnioWorker extends AbstractExecutorService implements Conf
      * @return the pending task list
      */
     protected List<Runnable> shutDownTaskPoolNow() {
-        return taskPool.shutdownNow();
+        return doPrivileged(new PrivilegedAction<List<Runnable>>() {
+            public List<Runnable> run() {
+                return taskPool.shutdownNow();
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
A backport of XNIO-235 to the branch 3.0  (EAP 6.4).

JIRA: https://issues.jboss.org/browse/XNIO-235
