### PR TITLE
Correct casting in BufferPipeInputStream#skip method

### DIFF
--- a/api/src/main/java/org/xnio/streams/BufferPipeInputStream.java
+++ b/api/src/main/java/org/xnio/streams/BufferPipeInputStream.java
@@ -239,7 +239,7 @@ public class BufferPipeInputStream extends InputStream {
                     break;
                 }
                 final ByteBuffer buffer = entry.getResource();
-                final int byteCnt = Math.min(buffer.remaining(), (int) Math.max((long)Integer.MAX_VALUE, qty));
+                final int byteCnt = (int) Math.min(buffer.remaining(), Math.max((long)Integer.MAX_VALUE, qty));
                 buffer.position(buffer.position() + byteCnt);
                 skipped += byteCnt;
                 qty -= byteCnt;


### PR DESCRIPTION
Parameter to skip method it is casted prematurely to int so if it is larger than Integer.MAX_VALUE then byteCnt is always evaluated to -1 which leads to infinite loop.
