### PR TITLE
Fix for XNIO-289. Client bind address table is not used when connecting.

### DIFF
--- a/api/src/main/java/org/xnio/XnioIoThread.java
+++ b/api/src/main/java/org/xnio/XnioIoThread.java
@@ -223,7 +223,7 @@ public abstract class XnioIoThread extends Thread implements XnioExecutor, XnioI
     public IoFuture<StreamConnection> openStreamConnection(SocketAddress destination, ChannelListener<? super StreamConnection> openListener, OptionMap optionMap) {
         Assert.checkNotNullParam("destination", destination);
         if (destination instanceof InetSocketAddress) {
-            return openTcpStreamConnection(Xnio.ANY_INET_ADDRESS, (InetSocketAddress) destination, openListener, null, optionMap);
+            return internalOpenTcpStreamConnection((InetSocketAddress) destination, openListener, null, optionMap);
         } else if (destination instanceof LocalSocketAddress) {
             return openLocalStreamConnection(Xnio.ANY_LOCAL_ADDRESS, (LocalSocketAddress) destination, openListener, null, optionMap);
         } else {
@@ -234,12 +234,17 @@ public abstract class XnioIoThread extends Thread implements XnioExecutor, XnioI
     public IoFuture<StreamConnection> openStreamConnection(SocketAddress destination, ChannelListener<? super StreamConnection> openListener, ChannelListener<? super BoundChannel> bindListener, OptionMap optionMap) {
         Assert.checkNotNullParam("destination", destination);
         if (destination instanceof InetSocketAddress) {
-            return openTcpStreamConnection(Xnio.ANY_INET_ADDRESS, (InetSocketAddress) destination, openListener, bindListener, optionMap);
+            return internalOpenTcpStreamConnection((InetSocketAddress) destination, openListener, bindListener, optionMap);
         } else if (destination instanceof LocalSocketAddress) {
             return openLocalStreamConnection(Xnio.ANY_LOCAL_ADDRESS, (LocalSocketAddress) destination, openListener, bindListener, optionMap);
         } else {
             throw msg.badSockType(destination.getClass());
         }
+    }
+    
+    private IoFuture<StreamConnection> internalOpenTcpStreamConnection(InetSocketAddress destination, ChannelListener<? super StreamConnection> openListener, ChannelListener<? super BoundChannel> bindListener, OptionMap optionMap) {
+        InetSocketAddress bindAddress = getWorker().getBindAddressTable().get(((InetSocketAddress)destination).getAddress());
+        return openTcpStreamConnection(bindAddress == null ? Xnio.ANY_INET_ADDRESS : bindAddress, (InetSocketAddress) destination, openListener, bindListener, optionMap);
     }
 
     public IoFuture<StreamConnection> openStreamConnection(SocketAddress bindAddress, SocketAddress destination, ChannelListener<? super StreamConnection> openListener, ChannelListener<? super BoundChannel> bindListener, OptionMap optionMap) {

--- a/nio-impl/src/main/java/org/xnio/nio/WorkerThread.java
+++ b/nio-impl/src/main/java/org/xnio/nio/WorkerThread.java
@@ -245,8 +245,6 @@ final class WorkerThread extends XnioIoThread implements XnioExecutor {
             return new FailedIoFuture<StreamConnection>(e);
         }
         try {
-            final InetSocketAddress realBindAddress =
-                bindAddress != null ? bindAddress : getWorker().getBindAddressTable().get(destinationAddress.getAddress());
             final SocketChannel channel = SocketChannel.open();
             boolean ok = false;
             try {
@@ -261,8 +259,8 @@ final class WorkerThread extends XnioIoThread implements XnioExecutor {
                 if (optionMap.contains(Options.SEND_BUFFER)) channel.socket().setSendBufferSize(optionMap.get(Options.SEND_BUFFER, -1));
                 final SelectionKey key = registerChannel(channel);
                 final NioSocketStreamConnection connection = new NioSocketStreamConnection(this, key, null);
-                if (realBindAddress != null || bindListener != null) {
-                    channel.socket().bind(realBindAddress);
+                if (bindAddress != null || bindListener != null) {
+                    channel.socket().bind(bindAddress);
                     ChannelListeners.invokeChannelListener(connection, bindListener);
                 }
                 if (channel.connect(destinationAddress)) {


### PR DESCRIPTION
Moved the table look-up in XnioIoThread, removed lookup done in WorkerThread.
Xnio.ANY_INET_ADDRESS is used only if no bind address found in the table.
