### PR TITLE
XNIO-297 IO worker connection count provides incorrect values

### DIFF
--- a/nio-impl/src/main/java/org/xnio/nio/QueuedNioTcpServer.java
+++ b/nio-impl/src/main/java/org/xnio/nio/QueuedNioTcpServer.java
@@ -408,14 +408,13 @@ final class QueuedNioTcpServer extends AbstractNioChannel<QueuedNioTcpServer> im
                 ok = true;
                 return newConnection;
             } finally {
-                if (! ok) safeClose(accepted);
+                if (! ok) {
+                    safeClose(accepted);
+                    handle.freeConnection();
+                }
             }
         } catch (IOException e) {
             return null;
-        } finally {
-            if (! ok) {
-                handle.freeConnection();
-            }
         }
         // by contract, only a resume will do
         return null;


### PR DESCRIPTION
https://issues.jboss.org/browse/XNIO-297
https://issues.jboss.org/browse/JBEAP-8346

```handle.freeConnection();``` decreases the counter - I think it should not be called in case when ```accepted``` is null on line 395. Therefore moving it one block deeper.