### PR TITLE
Make methods visible for metrics

### DIFF
--- a/api/src/main/java/org/xnio/XnioWorker.java
+++ b/api/src/main/java/org/xnio/XnioWorker.java
@@ -891,7 +891,7 @@ public abstract class XnioWorker extends AbstractExecutorService implements Conf
      *
      * @return the core worker pool size
      */
-    protected final int getCoreWorkerPoolSize() {
+    public final int getCoreWorkerPoolSize() {
         return coreSize;
     }
 
@@ -900,7 +900,7 @@ public abstract class XnioWorker extends AbstractExecutorService implements Conf
      *
      * @return the estimated number of busy threads in the worker pool
      */
-    protected final int getBusyWorkerThreadCount() {
+    public final int getBusyWorkerThreadCount() {
         return taskPool.getActiveCount();
     }
 
@@ -909,7 +909,7 @@ public abstract class XnioWorker extends AbstractExecutorService implements Conf
      *
      * @return the maximum worker pool size
      */
-    protected final int getMaxWorkerPoolSize() {
+    public final int getMaxWorkerPoolSize() {
         return taskPool.getMaximumPoolSize();
     }
 
@@ -918,7 +918,7 @@ public abstract class XnioWorker extends AbstractExecutorService implements Conf
      *
      * @return the estimated number of tasks
      */
-    protected final int getWorkerQueueSize() {
+    public final int getWorkerQueueSize() {
         return taskQueue.size();
     }
 

--- a/api/src/main/java/org/xnio/XnioWorker.java
+++ b/api/src/main/java/org/xnio/XnioWorker.java
@@ -886,6 +886,12 @@ public abstract class XnioWorker extends AbstractExecutorService implements Conf
      */
     protected abstract XnioIoThread chooseThread();
 
+    //==================================================
+    //
+    // Metrics methods
+    //
+    //==================================================
+
     /**
      * Get the core worker pool size.
      *


### PR DESCRIPTION
We're using bare Undertow as application server in our application platform, and we want to get some metrics about how the application server is working.
But unfortunately, we can't access the methods to return values we want.

If the methods below are accessible from other classes, we can get metrics we want.
What do you think about this change?