### PR TITLE
XNIO-283 add BusyWorkerThreadCount metric

### DIFF
--- a/api/src/main/java/org/xnio/XnioWorker.java
+++ b/api/src/main/java/org/xnio/XnioWorker.java
@@ -859,6 +859,15 @@ public abstract class XnioWorker extends AbstractExecutorService implements Conf
     }
 
     /**
+     * Get an estimate of the number of busy threads in the worker pool.
+     *
+     * @return the estimated number of busy threads in the worker pool
+     */
+    protected final int getBusyWorkerThreadCount() {
+        return taskPool.getActiveCount();
+    }
+
+    /**
      * Get the maximum worker pool size.
      *
      * @return the maximum worker pool size

--- a/api/src/main/java/org/xnio/management/XnioWorkerMXBean.java
+++ b/api/src/main/java/org/xnio/management/XnioWorkerMXBean.java
@@ -62,6 +62,13 @@ public interface XnioWorkerMXBean {
     int getMaxWorkerPoolSize();
 
     /**
+     * Get an estimate of the number of busy threads in the worker pool.
+     *
+     * @return the estimated number of busy threads in the worker pool
+     */
+    int getBusyWorkerThreadCount();
+
+    /**
      * Get the I/O thread count.
      *
      * @return the I/O thread count

--- a/nio-impl/src/main/java/org/xnio/nio/NioXnioWorker.java
+++ b/nio-impl/src/main/java/org/xnio/nio/NioXnioWorker.java
@@ -406,6 +406,10 @@ final class NioXnioWorker extends XnioWorker {
             return NioXnioWorker.this.getMaxWorkerPoolSize();
         }
 
+        public int getBusyWorkerThreadCount() {
+            return NioXnioWorker.this.getBusyWorkerThreadCount();
+        }
+
         public int getIoThreadCount() {
             return NioXnioWorker.this.getIoThreadCount();
         }


### PR DESCRIPTION
Backport [XNIO-283 Add metric for monitoring number of busy threads in the worker pool](https://issues.jboss.org/browse/XNIO-283) to 3.4 branch, which was incorporated to 3.5 branch (3.x branch) by https://github.com/xnio/xnio/commit/a6830bd73aee07d3e28ea10c5a771a26daf44363 

This metric is useful for monitoring the server load but not yet available in XNIO 3.4 branch, which is used by EAP 7.0.x. 