### PR TITLE
encapsulate trace log

### DIFF
--- a/nio-impl/src/main/java/org/xnio/nio/WorkerThread.java
+++ b/nio-impl/src/main/java/org/xnio/nio/WorkerThread.java
@@ -580,15 +580,19 @@ final class WorkerThread extends XnioIoThread implements XnioExecutor {
                     try {
                         ops = key.interestOps();
                         if (ops != 0) {
-                            selectorLog.tracef("Selected key %s for %s", key, key.channel());
+                            final SelectableChannel channel = key.channel();
+                            selectorLog.tracef("Selected key %s for %s", key, channel);
                             final NioHandle handle = (NioHandle) key.attachment();
                             if (handle == null) {
                                 cancelKey(key);
                             } else {
                                 // clear interrupt status
                                 Thread.interrupted();
-                                selectorLog.tracef("Calling handleReady key %s for %s", key.readyOps(), key.channel());
-                                handle.handleReady(key.readyOps());
+                                final int readyOps = key.readyOps();
+                                if (selectorLog.isTraceEnabled()) {
+                                    selectorLog.tracef("Calling handleReady key %s for %s", readyOps, channel);
+                                }
+                                handle.handleReady(readyOps);
                             }
                         }
                     } catch (CancelledKeyException ignored) {


### PR DESCRIPTION
I'm not sure that this PR is good as it may hide an issue I face instead of fixing it.

I encountered a problem when upgrade the netty-xnio-transport library to the latest XNIO release.
After some bisect, the regression was caused by https://github.com/xnio/xnio/commit/003535ef3e98b9db6bc2603d78386fb9c92d3c2c.

With that commit, the tests in netty-xnio-transport hangs as I end up in an infinite loop.
If I put the log inside a `if (traceEnabled)`, the tests passes again.
I don't understand why it impacts the tests. Note that if I replace the `selectorLog.trace` call with a `System.out.println`, the test passes.

With the current code (and an additional call to `System.out`) the test displays:

```
10:36:55.570 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.allocator.type: pooled
10:36:55.570 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.threadLocalDirectBufferSize: 65536
10:36:55.570 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.maxThreadLocalCharBufferSize: 16384
Calling handleReady key 16 for sun.nio.ch.ServerSocketChannelImpl[/0:0:0:0:0:0:0:1:53654]
Calling handleReady key 16 for sun.nio.ch.ServerSocketChannelImpl[/0:0:0:0:0:0:0:1:53654]
Calling handleReady key 16 for sun.nio.ch.ServerSocketChannelImpl[/0:0:0:0:0:0:0:1:53654]
...
Calling handleReady key 16 for sun.nio.ch.ServerSocketChannelImpl[/0:0:0:0:0:0:0:1:53654]
Calling handleReady key 8 for java.nio.channels.SocketChannel[connection-pending local=/0:0:0:0:0:0:0:0:53655 remote=/0:0:0:0:0:0:0:1:53654]
...
Calling handleReady key 16 for sun.nio.ch.ServerSocketChannelImpl[/0:0:0:0:0:0:0:1:53654]
Calling handleReady key 16 for sun.nio.ch.ServerSocketChannelImpl[/0:0:0:0:0:0:0:1:53654]
Calling handleReady key 8 for java.nio.channels.SocketChannel[connection-pending local=/0:0:0:0:0:0:0:0:53655 remote=/0:0:0:0:0:0:0:1:53654]
Calling handleReady key 16 for sun.nio.ch.ServerSocketChannelImpl[/0:0:0:0:0:0:0:1:53654]
```
the logs with the `OP_ACCEPT` and `OP_CONNECT` keys repeats ad nauseam and the test never stops.

With that commit (and an additional call to `System.out`), the test displays:

```
10:41:12.536 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.allocator.type: pooled
10:41:12.537 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.threadLocalDirectBufferSize: 65536
10:41:12.537 [main] DEBUG io.netty.buffer.ByteBufUtil - -Dio.netty.maxThreadLocalCharBufferSize: 16384
Calling handleReady key 16 for sun.nio.ch.ServerSocketChannelImpl[/0:0:0:0:0:0:0:1:53691]
Calling handleReady key 8 for java.nio.channels.SocketChannel[connection-pending local=/0:0:0:0:0:0:0:0:53692 remote=/0:0:0:0:0:0:0:1:53691]
10:41:12.622 [main] DEBUG io.netty.buffer.AbstractByteBuf - -Dio.netty.buffer.bytebuf.checkAccessible: true
10:41:12.626 [main] DEBUG io.netty.util.ResourceLeakDetectorFactory - Loaded default ResourceLeakDetector: io.netty.util.ResourceLeakDetector@1e67a849
10:41:12.630 [main] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.maxCapacityPerThread: 32768
10:41:12.630 [main] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.maxSharedCapacityFactor: 2
10:41:12.630 [main] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.linkCapacity: 16
10:41:12.630 [main] DEBUG io.netty.util.Recycler - -Dio.netty.recycler.ratio: 8
Calling handleReady key 1 for java.nio.channels.SocketChannel[connected local=/0:0:0:0:0:0:0:1:53691 remote=/0:0:0:0:0:0:0:1:53692]
Calling handleReady key 1 for java.nio.channels.SocketChannel[connected local=/0:0:0:0:0:0:0:1:53691 remote=/0:0:0:0:0:0:0:1:53692]
Calling handleReady key 1 for java.nio.channels.SocketChannel[connected local=/0:0:0:0:0:0:0:1:53691 remote=/0:0:0:0:0:0:0:1:53692]
```

and the test passes. We can see that I see only once the `OP_ACCEPT` and `OP_CONNECT` keys and then the test proceeds as usual

I don't understand why disabling the logs has such an impact on the test behaviour.

@jfdenise do you have an idea about this issue?