### PR TITLE
XNIO-320 Check for address resolution before using it to connect to

### DIFF
--- a/api/src/main/java/org/xnio/XnioIoThread.java
+++ b/api/src/main/java/org/xnio/XnioIoThread.java
@@ -243,8 +243,11 @@ public abstract class XnioIoThread extends Thread implements XnioExecutor, XnioI
     }
     
     private IoFuture<StreamConnection> internalOpenTcpStreamConnection(InetSocketAddress destination, ChannelListener<? super StreamConnection> openListener, ChannelListener<? super BoundChannel> bindListener, OptionMap optionMap) {
-        InetSocketAddress bindAddress = getWorker().getBindAddressTable().get(((InetSocketAddress)destination).getAddress());
-        return openTcpStreamConnection(bindAddress == null ? Xnio.ANY_INET_ADDRESS : bindAddress, (InetSocketAddress) destination, openListener, bindListener, optionMap);
+        if (destination.isUnresolved()) {
+            throw msg.cannotConnectToUnResolvedAddress(destination);
+        }
+        final InetSocketAddress bindAddress = getWorker().getBindAddressTable().get(destination.getAddress());
+        return openTcpStreamConnection(bindAddress == null ? Xnio.ANY_INET_ADDRESS : bindAddress, destination, openListener, bindListener, optionMap);
     }
 
     public IoFuture<StreamConnection> openStreamConnection(SocketAddress bindAddress, SocketAddress destination, ChannelListener<? super StreamConnection> openListener, ChannelListener<? super BoundChannel> bindListener, OptionMap optionMap) {

--- a/api/src/main/java/org/xnio/_private/Messages.java
+++ b/api/src/main/java/org/xnio/_private/Messages.java
@@ -23,6 +23,7 @@ import java.io.EOFException;
 import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.net.InetAddress;
+import java.net.InetSocketAddress;
 import java.net.SocketAddress;
 import java.nio.BufferOverflowException;
 import java.nio.BufferUnderflowException;
@@ -335,6 +336,9 @@ public interface Messages extends BasicLogger {
     @Message(id = 1010, value = "Failed to submit task to executor: %s (closing %s)")
     @LogMessage(level = ERROR)
     void executorSubmitFailed(RejectedExecutionException cause, Channel channel);
+
+    @Message(id = 1011, value = "Cannot connect to an unresolved address %s")
+    IllegalArgumentException cannotConnectToUnResolvedAddress(InetSocketAddress socketAddress);
 
     // Trace
 


### PR DESCRIPTION
The commit here contains a potential fix for the issue reported in https://issues.jboss.org/browse/XNIO-320. It adds a check to make sure the address it tries to connect to has been resolved.