### PR TITLE
[XNIO-324] Provide API to set task pool maximum queue size

### DIFF
--- a/api/src/main/java/org/xnio/Options.java
+++ b/api/src/main/java/org/xnio/Options.java
@@ -515,6 +515,11 @@ public final class Options {
     public static final Option<Integer> WORKER_TASK_MAX_THREADS = Option.simple(Options.class, "WORKER_TASK_MAX_THREADS", Integer.class);
 
     /**
+     * Specify the maximum queue size for the worker task thread pool.
+     */
+    public static final Option<Integer> WORKER_TASK_MAX_QUEUE_SIZE = Option.simple(Options.class, "WORKER_TASK_MAX_QUEUE_SIZE", Integer.class);
+
+    /**
      * Specify the number of milliseconds to keep non-core task threads alive.
      */
     public static final Option<Integer> WORKER_TASK_KEEPALIVE = Option.simple(Options.class, "WORKER_TASK_KEEPALIVE", Integer.class);

--- a/api/src/test/java/org/xnio/XnioWorkerTestCase.java
+++ b/api/src/test/java/org/xnio/XnioWorkerTestCase.java
@@ -668,6 +668,7 @@ public class XnioWorkerTestCase {
         assertTrue(xnioWorker.supportsOption(Options.WORKER_TASK_CORE_THREADS));
         assertTrue(xnioWorker.supportsOption(Options.WORKER_TASK_MAX_THREADS));
         assertTrue(xnioWorker.supportsOption(Options.WORKER_TASK_KEEPALIVE));
+        assertTrue(xnioWorker.supportsOption(Options.WORKER_TASK_MAX_QUEUE_SIZE));
         
         assertFalse(xnioWorker.supportsOption(Options.ALLOW_BLOCKING));
         assertFalse(xnioWorker.supportsOption(Options.MULTICAST));
@@ -766,6 +767,7 @@ public class XnioWorkerTestCase {
         builder.set(Options.WORKER_TASK_LIMIT, 0x8000);
         builder.set(Options.WORKER_TASK_CORE_THREADS, 10);
         builder.set(Options.WORKER_TASK_MAX_THREADS, 20);
+        builder.set(Options.WORKER_TASK_MAX_QUEUE_SIZE, 50);
         builder.set(Options.WORKER_TASK_KEEPALIVE, 300);
         builder.set(Options.THREAD_DAEMON, true);
 
@@ -776,6 +778,7 @@ public class XnioWorkerTestCase {
         assertNull(xnioWorker.getOption(Options.WORKER_TASK_LIMIT));
         assertEquals(10, (int) xnioWorker.getOption(Options.WORKER_TASK_CORE_THREADS));
         assertEquals(20, (int) xnioWorker.getOption(Options.WORKER_TASK_MAX_THREADS));
+        assertEquals(50, (int) xnioWorker.getOption(Options.WORKER_TASK_MAX_QUEUE_SIZE));
         assertEquals(300, (int) xnioWorker.getOption(Options.WORKER_TASK_KEEPALIVE));
     }
 


### PR DESCRIPTION
Added APIs:
Options.WORKER_TASK_MAX_QUEUE_SIZE
XnioWorker.Builder.getMaxWorkerPoolSize
XnioWorker.Builder.setMaxWorkerPoolSize