### PR TITLE
[XNIO-325] - SSL connection breakup causes java.lang.IllegalStateExce…

### DIFF
--- a/api/src/main/java/org/xnio/ssl/JsseSslConduitEngine.java
+++ b/api/src/main/java/org/xnio/ssl/JsseSslConduitEngine.java
@@ -594,7 +594,7 @@ final class JsseSslConduitEngine {
     public long unwrap(final ByteBuffer[] dsts, final int offset, final int length) throws IOException {
         assert ! Thread.holdsLock(getUnwrapLock());
         assert ! Thread.holdsLock(getWrapLock());
-        if (dsts.length == 0 || length == 0) {
+        if (dsts.length == 0 || length == 0 || isClosed()) {
             return 0L;
         }
         clearFlags(FIRST_HANDSHAKE | BUFFER_UNDERFLOW);

--- a/api/src/main/java/org/xnio/ssl/JsseSslStreamSourceConduit.java
+++ b/api/src/main/java/org/xnio/ssl/JsseSslStreamSourceConduit.java
@@ -109,7 +109,7 @@ final class JsseSslStreamSourceConduit extends AbstractStreamSourceConduit<Strea
         if (offs < 0 || offs > len || len < 0 || offs + len > dsts.length) {
             throw new ArrayIndexOutOfBoundsException();
         }
-        if ((!sslEngine.isDataAvailable() && sslEngine.isInboundClosed()) || sslEngine.isClosed()) {
+        if (sslEngine.isClosed() || (!sslEngine.isDataAvailable() && sslEngine.isInboundClosed())) {
             return -1;
         }
         final int readResult;


### PR DESCRIPTION
…ption: XNIO000017: Buffer was already freed

https://issues.jboss.org/browse/XNIO-325
3.x: https://github.com/xnio/xnio/pull/168
3.6: https://github.com/xnio/xnio/pull/169
3.5: https://github.com/xnio/xnio/pull/170