### PR TITLE
[XNIO-327] Increase bufferSize for org.xnio.ssl.JsseXnioSsl.bufferPool to avoid issues with the socket buffer being too small when the BouncyCastle JSSE provider is used

### DIFF
--- a/api/src/main/java/org/xnio/ssl/JsseXnioSsl.java
+++ b/api/src/main/java/org/xnio/ssl/JsseXnioSsl.java
@@ -66,7 +66,7 @@ import org.xnio.channels.ConnectedStreamChannel;
 public final class JsseXnioSsl extends XnioSsl {
     public static final boolean NEW_IMPL = doPrivileged((PrivilegedAction<Boolean>) () -> Boolean.valueOf(Boolean.parseBoolean(System.getProperty("org.xnio.ssl.new", "false")))).booleanValue();
 
-    static final Pool<ByteBuffer> bufferPool = new ByteBufferSlicePool(BufferAllocator.DIRECT_BYTE_BUFFER_ALLOCATOR, 17 * 1024, 17 * 1024 * 128);
+    static final Pool<ByteBuffer> bufferPool = new ByteBufferSlicePool(BufferAllocator.DIRECT_BYTE_BUFFER_ALLOCATOR, 21 * 1024, 21 * 1024 * 128);
     private final SSLContext sslContext;
 
     /**


### PR DESCRIPTION
See the following two issues for details:

https://issues.jboss.org/browse/XNIO-327
https://issues.jboss.org/browse/ELY-1624

3.x PR: https://github.com/xnio/xnio/pull/171