### PR TITLE
[XNIO-338] Avoid infinite loop in JsseSslConduitEngine#handleHandshake 

### DIFF
--- a/api/src/main/java/org/xnio/ssl/JsseSslConduitEngine.java
+++ b/api/src/main/java/org/xnio/ssl/JsseSslConduitEngine.java
@@ -469,6 +469,10 @@ final class JsseSslConduitEngine {
                         // given caller is reading, tell it to continue only if we can move away from  NEED_WRAP
                         // and flush any wrapped data we may have left
                         if (doFlush()) {
+                            if (result.getStatus() == SSLEngineResult.Status.CLOSED) {
+                                closeOutbound();
+                                return false;
+                            }
                             if (!handleWrapResult(result = engineWrap(Buffers.EMPTY_BYTE_BUFFER, buffer), true) || !doFlush()) {
                                 needWrap();
                                 return false;


### PR DESCRIPTION
Avoid infinite loop in JsseSslConduitEngine#handleHandshake when the SSLEngineResult.HandshakeStatus is NEED_WRAP and the SSLEngineResult.Status is CLOSED by ensuring that closeOutbound is called

https://issues.jboss.org/browse/XNIO-338