### PR TITLE
XNIO-344 WatchServiceFileSystemWatcher has a possibility to prune all…

### DIFF
--- a/nio-impl/src/main/java/org/xnio/nio/WatchServiceFileSystemWatcher.java
+++ b/nio-impl/src/main/java/org/xnio/nio/WatchServiceFileSystemWatcher.java
@@ -126,6 +126,16 @@ class WatchServiceFileSystemWatcher implements FileSystemWatcher, Runnable {
                             while (it.hasNext()) {
                                 FileChangeEvent event = it.next();
                                 if (event.getType() == FileChangeEvent.Type.MODIFIED) {
+                                    if (addedFiles.contains(event.getFile()) &&
+                                            deletedFiles.contains(event.getFile())) {
+                                        // XNIO-344
+                                        // All file change events (ADDED, REMOVED and MODIFIED) occurred here.
+                                        // This happens when an updated file is moved from the different
+                                        // filesystems or the directory having different project quota on Linux.
+                                        // ADDED and REMOVED events will be removed in the latter conditional branching.
+                                        // So, this MODIFIED event needs to be kept for the file change notification.
+                                        continue;
+                                    }
                                     if (addedFiles.contains(event.getFile()) ||
                                             deletedFiles.contains(event.getFile())) {
                                         it.remove();


### PR DESCRIPTION
… file change events and miss to invoke FileChangeCallback

PR for 3.x branch: https://github.com/xnio/xnio/pull/198
XNIO JIRA: https://issues.jboss.org/browse/XNIO-344
JBEAP JIRA: https://issues.jboss.org/browse/JBEAP-17308