### PR TITLE
[XNIO-348] Enhance XNIO error logging for notifier failure

### DIFF
--- a/api/src/main/java/org/xnio/AbstractIoFuture.java
+++ b/api/src/main/java/org/xnio/AbstractIoFuture.java
@@ -719,7 +719,7 @@ public abstract class AbstractIoFuture<T> implements IoFuture<T> {
             try {
                 notifier.notify(future, attachment);
             } catch (Throwable t) {
-                futureMsg.notifierFailed(t, notifier);
+                futureMsg.notifierFailed(t, notifier, attachment);
             }
         }
     }

--- a/api/src/main/java/org/xnio/_private/Messages.java
+++ b/api/src/main/java/org/xnio/_private/Messages.java
@@ -310,9 +310,9 @@ public interface Messages extends BasicLogger {
     @Message(id = 1002, value = "Operation was cancelled")
     CancellationException opCancelled();
 
-    @Message(id = 1003, value = "Running IoFuture notifier %s failed")
+    @Message(id = 1003, value = "Running IoFuture notifier %s (with attachment %s) failed")
     @LogMessage(level = WARN)
-    void notifierFailed(@Cause Throwable cause, IoFuture.Notifier<?, ?> notifier);
+    void notifierFailed(@Cause Throwable cause, IoFuture.Notifier<?, ?> notifier, Object attachment);
 
     @Message(id = 1004, value = "Operation timed out")
     TimeoutException opTimedOut();


### PR DESCRIPTION
Issue: https://issues.jboss.org/browse/XNIO-348

This will add the attachment to the error message allowing us to provide more information in the attachment.toString gives us the opportunity to override the toString of whatever object class the attachment represents.

3.7 PR: #203
3.5 PR: #202
3.x PR: #204