### PR TITLE
Introduce alternative queued acceptor

### DIFF
--- a/nio-impl/pom.xml
+++ b/nio-impl/pom.xml
@@ -40,6 +40,7 @@
         <xnio.nio.selector.main/>
         <xnio.nio.selector.temp/>
         <xnio.nio.selector.provider/>
+        <xnio.nio.alt-queued-server>true</xnio.nio.alt-queued-server>
     </properties>
 
     <dependencies>
@@ -154,6 +155,10 @@
                         <property>
                             <name>org.xnio.ssl.new</name>
                             <value>${org.xnio.ssl.new}</value>
+                        </property>
+                        <property>
+                            <name>xnio.nio.alt-queued-server</name>
+                            <value>${xnio.nio.alt-queued-server}</value>
                         </property>
                     </systemProperties>
                     <enableAssertions>true</enableAssertions>

--- a/nio-impl/src/main/java/org/xnio/nio/AbstractNioChannel.java
+++ b/nio-impl/src/main/java/org/xnio/nio/AbstractNioChannel.java
@@ -21,7 +21,6 @@ package org.xnio.nio;
 import org.xnio.ChannelListener;
 import org.xnio.ChannelListeners;
 import org.xnio.XnioIoThread;
-import org.xnio.XnioWorker;
 import org.xnio.channels.CloseableChannel;
 
 abstract class AbstractNioChannel<C extends AbstractNioChannel<C>> implements CloseableChannel {
@@ -37,7 +36,7 @@ abstract class AbstractNioChannel<C extends AbstractNioChannel<C>> implements Cl
         this.worker = worker;
     }
 
-    public final XnioWorker getWorker() {
+    public final NioXnioWorker getWorker() {
         return worker;
     }
 

--- a/nio-impl/src/main/java/org/xnio/nio/Log.java
+++ b/nio-impl/src/main/java/org/xnio/nio/Log.java
@@ -125,6 +125,10 @@ interface Log extends BasicLogger {
     @Message(id = 8000, value = "Received an I/O error on selection: %s")
     void selectionError(IOException e);
 
+    @LogMessage(level = WARN)
+    @Message(id = 8001, value = "Socket accept failed, backing off for %2$d milliseconds: %1$s")
+    void acceptFailed(IOException problem, int backOffTime);
+
     // Trace
 
     @LogMessage(level = TRACE)

--- a/nio-impl/src/main/java/org/xnio/nio/NioTcpServer.java
+++ b/nio-impl/src/main/java/org/xnio/nio/NioTcpServer.java
@@ -112,24 +112,35 @@ final class NioTcpServer extends AbstractNioChannel<NioTcpServer> implements Acc
 
     private static final AtomicLongFieldUpdater<NioTcpServer> connectionStatusUpdater = AtomicLongFieldUpdater.newUpdater(NioTcpServer.class, "connectionStatus");
 
-    NioTcpServer(final NioXnioWorker worker, final ServerSocketChannel channel, final OptionMap optionMap) throws IOException {
+    NioTcpServer(final NioXnioWorker worker, final ServerSocketChannel channel, final OptionMap optionMap, final boolean useAcceptThreadOnly) throws IOException {
         super(worker);
         this.channel = channel;
-        final WorkerThread[] threads = worker.getAll();
-        final int threadCount = threads.length;
-        if (threadCount == 0) {
-            throw log.noThreads();
-        }
-        final int tokens = optionMap.get(Options.BALANCING_TOKENS, -1);
-        final int connections = optionMap.get(Options.BALANCING_CONNECTIONS, 16);
-        if (tokens != -1) {
-            if (tokens < 1 || tokens >= threadCount) {
-                throw log.balancingTokens();
+        final WorkerThread[] threads;
+        final int threadCount;
+        final int tokens;
+        final int connections;
+        if (useAcceptThreadOnly) {
+            threads = new WorkerThread[] { worker.getAcceptThread() };
+            threadCount = 1;
+            tokens = 0;
+            connections = 0;
+        } else {
+            threads = worker.getAll();
+            threadCount = threads.length;
+            if (threadCount == 0) {
+                throw log.noThreads();
             }
-            if (connections < 1) {
-                throw log.balancingConnectionCount();
+            tokens = optionMap.get(Options.BALANCING_TOKENS, -1);
+            connections = optionMap.get(Options.BALANCING_CONNECTIONS, 16);
+            if (tokens != -1) {
+                if (tokens < 1 || tokens >= threadCount) {
+                    throw log.balancingTokens();
+                }
+                if (connections < 1) {
+                    throw log.balancingConnectionCount();
+                }
+                tokenConnectionCount = connections;
             }
-            tokenConnectionCount = connections;
         }
         socket = channel.socket();
         if (optionMap.contains(Options.SEND_BUFFER)) {
@@ -383,7 +394,12 @@ final class NioTcpServer extends AbstractNioChannel<NioTcpServer> implements Acc
         if (current == null) {
             return null;
         }
-        final NioTcpServerHandle handle = handles[current.getNumber()];
+        final NioTcpServerHandle handle;
+        if (handles.length == 1) {
+            handle = handles[0];
+        } else {
+            handle = handles[current.getNumber()];
+        }
         if (! handle.getConnection()) {
             return null;
         }

--- a/nio-impl/src/main/java/org/xnio/nio/NioTcpServer.java
+++ b/nio-impl/src/main/java/org/xnio/nio/NioTcpServer.java
@@ -379,6 +379,9 @@ final class NioTcpServer extends AbstractNioChannel<NioTcpServer> implements Acc
 
     public NioSocketStreamConnection accept() throws IOException {
         final WorkerThread current = WorkerThread.getCurrent();
+        if (current == null) {
+            return null;
+        }
         final NioTcpServerHandle handle = handles[current.getNumber()];
         if (! handle.getConnection()) {
             return null;

--- a/nio-impl/src/main/java/org/xnio/nio/NioTcpServer.java
+++ b/nio-impl/src/main/java/org/xnio/nio/NioTcpServer.java
@@ -27,6 +27,7 @@ import java.net.InetSocketAddress;
 import java.net.ServerSocket;
 import java.net.Socket;
 import java.net.SocketAddress;
+import java.nio.channels.ClosedChannelException;
 import java.nio.channels.SelectionKey;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
@@ -377,7 +378,7 @@ final class NioTcpServer extends AbstractNioChannel<NioTcpServer> implements Acc
         return (int) ((value & CONN_LOW_MASK) >> CONN_LOW_BIT);
     }
 
-    public NioSocketStreamConnection accept() throws IOException {
+    public NioSocketStreamConnection accept() throws ClosedChannelException {
         final WorkerThread current = WorkerThread.getCurrent();
         if (current == null) {
             return null;
@@ -427,6 +428,8 @@ final class NioTcpServer extends AbstractNioChannel<NioTcpServer> implements Acc
             } finally {
                 if (! ok) safeClose(accepted);
             }
+        } catch (ClosedChannelException e) {
+            throw e;
         } catch (IOException e) {
             return null;
         } finally {

--- a/nio-impl/src/main/java/org/xnio/nio/NioXnio.java
+++ b/nio-impl/src/main/java/org/xnio/nio/NioXnio.java
@@ -47,6 +47,7 @@ final class NioXnio extends Xnio {
 
     static final boolean IS_HP_UX;
     static final boolean HAS_BUGGY_EVENT_PORT;
+    static final boolean USE_ALT_QUEUED_SERVER;
 
     interface SelectorCreator {
         Selector open() throws IOException;
@@ -64,6 +65,7 @@ final class NioXnio extends Xnio {
                 return Boolean.valueOf(System.getProperty("os.name", "unknown").equalsIgnoreCase("hp-ux"));
             }
         }).booleanValue();
+        USE_ALT_QUEUED_SERVER = Boolean.parseBoolean(AccessController.doPrivileged(new ReadPropertyAction("xnio.nio.alt-queued-server", "true")));
         // if a JDK is released with a fix, we can try to detect it and set this to "false" for those JDKs.
         HAS_BUGGY_EVENT_PORT = true;
     }

--- a/nio-impl/src/main/java/org/xnio/nio/NioXnioWorker.java
+++ b/nio-impl/src/main/java/org/xnio/nio/NioXnioWorker.java
@@ -180,7 +180,12 @@ final class NioXnioWorker extends XnioWorker {
                 channel.socket().bind(bindAddress);
             }
             if (false) {
-                final NioTcpServer server = new NioTcpServer(this, channel, optionMap);
+                final NioTcpServer server = new NioTcpServer(this, channel, optionMap, false);
+                server.setAcceptListener(acceptListener);
+                ok = true;
+                return server;
+            } else if (NioXnio.USE_ALT_QUEUED_SERVER) {
+                final QueuedNioTcpServer2 server = new QueuedNioTcpServer2(new NioTcpServer(this, channel, optionMap, true));
                 server.setAcceptListener(acceptListener);
                 ok = true;
                 return server;

--- a/nio-impl/src/main/java/org/xnio/nio/QueuedNioTcpServer2.java
+++ b/nio-impl/src/main/java/org/xnio/nio/QueuedNioTcpServer2.java
@@ -1,0 +1,174 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2019 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.xnio.nio;
+
+import java.io.IOException;
+import java.net.SocketAddress;
+import java.nio.channels.ClosedChannelException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Queue;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
+
+import org.wildfly.common.Assert;
+import org.xnio.ChannelListener;
+import org.xnio.ChannelListeners;
+import org.xnio.Option;
+import org.xnio.StreamConnection;
+import org.xnio.XnioExecutor;
+import org.xnio.XnioIoThread;
+import org.xnio.channels.AcceptListenerSettable;
+import org.xnio.channels.AcceptingChannel;
+
+final class QueuedNioTcpServer2 extends AbstractNioChannel<QueuedNioTcpServer2> implements AcceptingChannel<StreamConnection>, AcceptListenerSettable<QueuedNioTcpServer2> {
+    private final NioTcpServer realServer;
+    private final List<Queue<StreamConnection>> acceptQueues;
+
+    private final Runnable acceptTask = this::acceptTask;
+
+    private volatile ChannelListener<? super QueuedNioTcpServer2> acceptListener;
+
+    QueuedNioTcpServer2(final NioTcpServer realServer) {
+        super(realServer.getWorker());
+        this.realServer = realServer;
+        final NioXnioWorker worker = realServer.getWorker();
+        final int cnt = worker.getIoThreadCount();
+        acceptQueues = new ArrayList<>(cnt);
+        for (int i = 0; i < cnt; i ++) {
+            acceptQueues.add(new LinkedBlockingQueue<>());
+        }
+        realServer.getCloseSetter().set(ignored -> invokeCloseHandler());
+        realServer.getAcceptSetter().set(ignored -> handleReady());
+    }
+
+    public StreamConnection accept() throws IOException {
+        final WorkerThread current = WorkerThread.getCurrent();
+        if (current == null) {
+            return null;
+        }
+        final Queue<StreamConnection> socketChannels = acceptQueues.get(current.getNumber());
+        final StreamConnection connection = socketChannels.poll();
+        if (connection == null) {
+            if (! realServer.isOpen()) {
+                throw new ClosedChannelException();
+            }
+        }
+        return connection;
+    }
+
+    public ChannelListener<? super QueuedNioTcpServer2> getAcceptListener() {
+        return acceptListener;
+    }
+
+    public void setAcceptListener(final ChannelListener<? super QueuedNioTcpServer2> listener) {
+        this.acceptListener = listener;
+    }
+
+    public ChannelListener.Setter<QueuedNioTcpServer2> getAcceptSetter() {
+        return new Setter<QueuedNioTcpServer2>(this);
+    }
+
+    public SocketAddress getLocalAddress() {
+        return realServer.getLocalAddress();
+    }
+
+    public <A extends SocketAddress> A getLocalAddress(final Class<A> type) {
+        return realServer.getLocalAddress(type);
+    }
+
+    public void suspendAccepts() {
+        realServer.suspendAccepts();
+    }
+
+    public void resumeAccepts() {
+        realServer.resumeAccepts();
+    }
+
+    public boolean isAcceptResumed() {
+        return realServer.isAcceptResumed();
+    }
+
+    public void wakeupAccepts() {
+        realServer.wakeupAccepts();
+    }
+
+    public void awaitAcceptable() {
+        throw Assert.unsupported();
+    }
+
+    public void awaitAcceptable(final long time, final TimeUnit timeUnit) {
+        throw Assert.unsupported();
+    }
+
+    @Deprecated
+    public XnioExecutor getAcceptThread() {
+        return getIoThread();
+    }
+
+    public void close() throws IOException {
+        realServer.close();
+    }
+
+    public boolean isOpen() {
+        return realServer.isOpen();
+    }
+
+    public boolean supportsOption(final Option<?> option) {
+        return realServer.supportsOption(option);
+    }
+
+    public <T> T getOption(final Option<T> option) throws IOException {
+        return realServer.getOption(option);
+    }
+
+    public <T> T setOption(final Option<T> option, final T value) throws IllegalArgumentException, IOException {
+        return realServer.setOption(option, value);
+    }
+
+    void handleReady() {
+        NioSocketStreamConnection connection;
+        try {
+            connection = realServer.accept();
+        } catch (ClosedChannelException e) {
+            return;
+        }
+        while (connection != null) {
+            final XnioIoThread thread = connection.getIoThread();
+            final Queue<StreamConnection> queue = acceptQueues.get(thread.getNumber());
+            queue.add(connection);
+            thread.execute(acceptTask);
+            try {
+                connection = realServer.accept();
+            } catch (ClosedChannelException e) {
+                return;
+            }
+        }
+    }
+
+    void acceptTask() {
+        final WorkerThread current = WorkerThread.getCurrent();
+        assert current != null;
+        final Queue<StreamConnection> queue = acceptQueues.get(current.getNumber());
+        ChannelListeners.invokeChannelListener(QueuedNioTcpServer2.this, getAcceptListener());
+        if (! queue.isEmpty()) {
+            current.execute(acceptTask);
+        }
+    }
+}


### PR DESCRIPTION
Fixes the following issues:

- https://issues.jboss.org/browse/XNIO-258
- https://issues.jboss.org/browse/XNIO-286
- https://issues.jboss.org/browse/XNIO-335
- https://issues.jboss.org/browse/XNIO-265

The alternative queued acceptor has to be explicitly enabled by setting the system property `xnio.nio.alt-queued-server` to `true`.  The default may be changed to `true` in future releases.