### PR TITLE
[XNIO-358] Remove finally block that adds sliced reused buffer to DIR…

### DIFF
--- a/api/src/main/java/org/xnio/ByteBufferSlicePool.java
+++ b/api/src/main/java/org/xnio/ByteBufferSlicePool.java
@@ -155,15 +155,11 @@ public final class ByteBufferSlicePool implements Pool<ByteBuffer> {
         // only true if using direct allocation
         if (directBuffers != null) {
             ByteBuffer region = FREE_DIRECT_BUFFERS.poll();
-            try {
-                if (region != null) {
-                    return sliceReusedBuffer(region, buffersPerRegion, bufferSize);
-                }
-                region = allocator.allocate(buffersPerRegion * bufferSize);
-                return sliceAllocatedBuffer(region, buffersPerRegion, bufferSize);
-            } finally {
-                directBuffers.add(region);
+            if (region != null) {
+                return sliceReusedBuffer(region, buffersPerRegion, bufferSize);
             }
+            region = allocator.allocate(buffersPerRegion * bufferSize);
+            return sliceAllocatedBuffer(region, buffersPerRegion, bufferSize);
         }
         return sliceAllocatedBuffer(
                 allocator.allocate(buffersPerRegion * bufferSize),


### PR DESCRIPTION
…ECT_BUFFERS at allocateSlices.

Jira: https://issues.redhat.com/browse/XNIO-358

3.x PR: https://github.com/xnio/xnio/pull/214