### PR TITLE
[XNIO-360] At JsseSslConduitEngine, allocate an expanded buffer when …

### DIFF
--- a/api/src/main/java/org/xnio/_private/Messages.java
+++ b/api/src/main/java/org/xnio/_private/Messages.java
@@ -240,6 +240,10 @@ public interface Messages extends BasicLogger {
     @Message(id = 306, value = "SSL connection is not from this provider")
     IllegalArgumentException notFromThisProvider();
 
+    @Message(id = 307, value = "Failed to close ssl engine when handling exception %s")
+    @LogMessage(level = WARN)
+    void failedToCloseSSLEngine(@Cause Throwable cause, Exception originalException);
+
     // I/O errors
 
     @Message(id = 800, value = "Read timed out")
@@ -353,4 +357,8 @@ public interface Messages extends BasicLogger {
     @Message(value = "Shutting down reads on %s failed")
     @LogMessage(level = TRACE)
     void resourceReadShutdownFailed(@Cause Throwable cause, Object resource);
+
+    @Message(value = "Expanded buffer enabled due to overflow with empty buffer, expanded buffer size is %s")
+    @LogMessage(level = TRACE)
+    void expandedSslBufferEnabled(int bufferSize);
 }

--- a/nio-impl/pom.xml
+++ b/nio-impl/pom.xml
@@ -164,6 +164,7 @@
                     <enableAssertions>true</enableAssertions>
                     <redirectTestOutputToFile>true</redirectTestOutputToFile>
                     <trimStackTrace>false</trimStackTrace>
+                    <reuseForks>false</reuseForks>
                 </configuration>
             </plugin>
             <plugin>

--- a/nio-impl/src/test/java/org/xnio/nio/test/AbstractNioSslBufferExpansionTcpTest.java
+++ b/nio-impl/src/test/java/org/xnio/nio/test/AbstractNioSslBufferExpansionTcpTest.java
@@ -1,0 +1,51 @@
+/*
+ * JBoss, Home of Professional Open Source
+ *
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.xnio.nio.test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.Socket;
+
+import org.xnio.ChannelListener;
+import org.xnio.XnioWorker;
+import org.xnio.channels.AcceptingChannel;
+import org.xnio.channels.ConnectedChannel;
+import org.xnio.channels.StreamSinkChannel;
+import org.xnio.channels.StreamSourceChannel;
+
+/**
+ * Superclass for ssl tcp test cases to verify if
+ * {@link javax.net.ssl.SSLEngineResult.Status#BUFFER_OVERFLOW}
+ * is handled appropriately.
+ * 
+ * @author <a href="mailto:frainone@redhat.com">Flavia Rainone</a>
+ *
+ */
+public abstract class AbstractNioSslBufferExpansionTcpTest<T extends ConnectedChannel, R extends StreamSourceChannel, W extends StreamSinkChannel> extends AbstractNioSslTcpTest<T, R, W> {
+
+    @Override
+    protected AcceptingChannel<? extends T> startServer(XnioWorker worker, final ChannelListener<? super T> serverHandler) throws
+            IOException {
+        AcceptingChannel<? extends T> server = super.startServer(worker, serverHandler);
+        // server attack
+        Socket socket = new Socket("127.0.0.1", SERVER_PORT);
+        OutputStream outputStream = socket.getOutputStream();
+        outputStream.write(new byte[]{0x16, 0x3, 0x3, 0x71, 0x41}, 0, 5);
+        return server;
+    }
+}

--- a/nio-impl/src/test/java/org/xnio/nio/test/NioSslBufferExpansionTcpChannelTestCase.java
+++ b/nio-impl/src/test/java/org/xnio/nio/test/NioSslBufferExpansionTcpChannelTestCase.java
@@ -1,0 +1,122 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ * Copyright 2020 Red Hat, Inc., and individual contributors
+ * as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.xnio.nio.test;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.URL;
+
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.xnio.ChannelListener;
+import org.xnio.IoFuture;
+import org.xnio.OptionMap;
+import org.xnio.Xnio;
+import org.xnio.XnioWorker;
+import org.xnio.channels.AcceptingChannel;
+import org.xnio.channels.BoundChannel;
+import org.xnio.channels.ConnectedSslStreamChannel;
+import org.xnio.ssl.XnioSsl;
+
+/**
+ * Test for {@code XnioSsl} channels with a
+ * {@link javax.net.ssl.SSLEngineResult.Status#BUFFER_OVERFLOW} wrap result.
+ * 
+ * @author <a href="mailto:frainone@redhat.com">Flavia Rainone</a>
+ *
+ */
+public class NioSslBufferExpansionTcpChannelTestCase extends
+        AbstractNioSslBufferExpansionTcpTest<ConnectedSslStreamChannel, ConnectedSslStreamChannel, ConnectedSslStreamChannel> {
+
+    private XnioSsl xnioSsl;
+    private static final String KEY_STORE_PROPERTY = "javax.net.ssl.keyStore";
+    private static final String KEY_STORE_PASSWORD_PROPERTY = "javax.net.ssl.keyStorePassword";
+    private static final String TRUST_STORE_PROPERTY = "javax.net.ssl.trustStore";
+    private static final String TRUST_STORE_PASSWORD_PROPERTY = "javax.net.ssl.trustStorePassword";
+    private static final String DEFAULT_KEY_STORE = "keystore.jks";
+    private static final String DEFAULT_KEY_STORE_PASSWORD = "jboss-remoting-test";
+
+    @BeforeClass
+    public static void setKeyStoreAndTrustStore() {
+        final URL storePath = NioSslBufferExpansionTcpChannelTestCase.class.getClassLoader().getResource(DEFAULT_KEY_STORE);
+        if (System.getProperty(KEY_STORE_PROPERTY) == null) {
+            System.setProperty(KEY_STORE_PROPERTY, storePath.getFile());
+        }
+        if (System.getProperty(KEY_STORE_PASSWORD_PROPERTY) == null) {
+            System.setProperty(KEY_STORE_PASSWORD_PROPERTY, DEFAULT_KEY_STORE_PASSWORD);
+        }
+        if (System.getProperty(TRUST_STORE_PROPERTY) == null) {
+            System.setProperty(TRUST_STORE_PROPERTY, storePath.getFile());
+        }
+        if (System.getProperty(TRUST_STORE_PASSWORD_PROPERTY) == null) {
+            System.setProperty(TRUST_STORE_PASSWORD_PROPERTY, DEFAULT_KEY_STORE_PASSWORD);
+        }
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    protected AcceptingChannel<? extends ConnectedSslStreamChannel> createServer(XnioWorker worker, InetSocketAddress address,
+            ChannelListener<AcceptingChannel<ConnectedSslStreamChannel>> openListener, OptionMap optionMap) throws IOException {
+        return xnioSsl.createSslTcpServer(worker, address,  openListener,  optionMap);
+    }
+
+    @SuppressWarnings("deprecation")
+    @Override
+    protected IoFuture<? extends ConnectedSslStreamChannel> connect(XnioWorker worker, InetSocketAddress address,
+            ChannelListener<ConnectedSslStreamChannel> openListener, ChannelListener<? super BoundChannel> bindListener,
+            OptionMap optionMap) {
+        return xnioSsl.connectSsl(worker, address,  openListener, bindListener, optionMap);
+    }
+
+    @Override
+    protected void setReadListener(ConnectedSslStreamChannel channel, ChannelListener<ConnectedSslStreamChannel> readListener) {
+        channel.getReadSetter().set(readListener);
+    }
+
+    @Override
+    protected void setWriteListener(ConnectedSslStreamChannel channel, ChannelListener<ConnectedSslStreamChannel> writeListener) {
+        channel.getWriteSetter().set(writeListener);
+    }
+
+    @Override
+    protected void resumeReads(ConnectedSslStreamChannel channel) {
+        channel.resumeReads();
+    }
+
+    @Override
+    protected void resumeWrites(ConnectedSslStreamChannel channel) {
+        channel.resumeWrites();
+    }
+
+    @Override
+    protected void shutdownReads(ConnectedSslStreamChannel channel) throws IOException {
+        channel.shutdownReads();
+    }
+
+    @Override
+    protected void shutdownWrites(ConnectedSslStreamChannel channel) throws IOException {
+        channel.shutdownWrites();
+    }
+
+    @Override
+    protected void doConnectionTest(final Runnable body, final ChannelListener<? super ConnectedSslStreamChannel> clientHandler, final ChannelListener<? super ConnectedSslStreamChannel> serverHandler) throws Exception {
+        xnioSsl = Xnio.getInstance("nio", NioSslBufferExpansionTcpChannelTestCase.class.getClassLoader()).getSslProvider(OptionMap.EMPTY);
+        super.doConnectionTest(body,  clientHandler, serverHandler);
+    }
+}

--- a/nio-impl/src/test/java/org/xnio/nio/test/NioSslBufferExpansionTcpConnectionTestCase.java
+++ b/nio-impl/src/test/java/org/xnio/nio/test/NioSslBufferExpansionTcpConnectionTestCase.java
@@ -1,0 +1,119 @@
+/*
+ * JBoss, Home of Professional Open Source
+ *
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.xnio.nio.test;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.URL;
+
+import org.junit.BeforeClass;
+import org.xnio.ChannelListener;
+import org.xnio.IoFuture;
+import org.xnio.OptionMap;
+import org.xnio.Xnio;
+import org.xnio.XnioWorker;
+import org.xnio.channels.AcceptingChannel;
+import org.xnio.channels.BoundChannel;
+import org.xnio.conduits.ConduitStreamSinkChannel;
+import org.xnio.conduits.ConduitStreamSourceChannel;
+import org.xnio.ssl.SslConnection;
+import org.xnio.ssl.XnioSsl;
+
+/**
+ * Test for {@code XnioSsl} connections with a
+ * {@link javax.net.ssl.SSLEngineResult.Status#BUFFER_OVERFLOW} wrap result.
+ * 
+ * @author <a href="mailto:frainone@redhat.com">Flavia Rainone</a>
+ *
+ */
+public class NioSslBufferExpansionTcpConnectionTestCase extends
+        AbstractNioSslBufferExpansionTcpTest<SslConnection, ConduitStreamSourceChannel, ConduitStreamSinkChannel> {
+    private XnioSsl xnioSsl;
+    private static final String KEY_STORE_PROPERTY = "javax.net.ssl.keyStore";
+    private static final String KEY_STORE_PASSWORD_PROPERTY = "javax.net.ssl.keyStorePassword";
+    private static final String TRUST_STORE_PROPERTY = "javax.net.ssl.trustStore";
+    private static final String TRUST_STORE_PASSWORD_PROPERTY = "javax.net.ssl.trustStorePassword";
+    private static final String DEFAULT_KEY_STORE = "keystore.jks";
+    private static final String DEFAULT_KEY_STORE_PASSWORD = "jboss-remoting-test";
+
+    @BeforeClass
+    public static void setKeyStoreAndTrustStore() {
+        final URL storePath = NioSslTcpChannelTestCase.class.getClassLoader().getResource(DEFAULT_KEY_STORE);
+        if (System.getProperty(KEY_STORE_PROPERTY) == null) {
+            System.setProperty(KEY_STORE_PROPERTY, storePath.getFile());
+        }
+        if (System.getProperty(KEY_STORE_PASSWORD_PROPERTY) == null) {
+            System.setProperty(KEY_STORE_PASSWORD_PROPERTY, DEFAULT_KEY_STORE_PASSWORD);
+        }
+        if (System.getProperty(TRUST_STORE_PROPERTY) == null) {
+            System.setProperty(TRUST_STORE_PROPERTY, storePath.getFile());
+        }
+        if (System.getProperty(TRUST_STORE_PASSWORD_PROPERTY) == null) {
+            System.setProperty(TRUST_STORE_PASSWORD_PROPERTY, DEFAULT_KEY_STORE_PASSWORD);
+        }
+    }
+
+    @Override
+    protected AcceptingChannel<? extends SslConnection> createServer(XnioWorker worker, InetSocketAddress address,
+            ChannelListener<AcceptingChannel<SslConnection>> openListener, OptionMap optionMap) throws IOException {
+        return xnioSsl.createSslConnectionServer(worker, address,  openListener,  optionMap);
+    }
+
+    @Override
+    protected IoFuture<? extends SslConnection> connect(XnioWorker worker, InetSocketAddress address,
+            ChannelListener<SslConnection> openListener, ChannelListener<? super BoundChannel> bindListener,
+            OptionMap optionMap) {
+        return xnioSsl.openSslConnection(worker, address,  openListener, bindListener, optionMap);
+    }
+
+    @Override
+    protected void setReadListener(SslConnection connection, ChannelListener<ConduitStreamSourceChannel> readListener) {
+        connection.getSourceChannel().setReadListener(readListener);
+    }
+
+    @Override
+    protected void setWriteListener(SslConnection connection, ChannelListener<ConduitStreamSinkChannel> writeListener) {
+        connection.getSinkChannel().setWriteListener(writeListener);
+    }
+
+    @Override
+    protected void resumeReads(SslConnection connection) {
+        connection.getSourceChannel().resumeReads();
+    }
+
+    @Override
+    protected void resumeWrites(SslConnection connection) {
+        connection.getSinkChannel().resumeWrites();
+    }
+
+    @Override
+    protected void shutdownReads(SslConnection connection) throws IOException {
+        connection.getSourceChannel().shutdownReads();
+    }
+
+    @Override
+    protected void shutdownWrites(SslConnection connection) throws IOException {
+        connection.getSinkChannel().shutdownWrites();
+    }
+
+    @Override
+    protected void doConnectionTest(final Runnable body, final ChannelListener<? super SslConnection> clientHandler, final ChannelListener<? super SslConnection> serverHandler) throws Exception {
+        xnioSsl = Xnio.getInstance("nio", NioSslTcpChannelTestCase.class.getClassLoader()).getSslProvider(OptionMap.EMPTY);
+        super.doConnectionTest(body,  clientHandler, serverHandler);
+    }
+}

--- a/nio-impl/src/test/java/org/xnio/nio/test/NioSslRandomlyTimedBufferExpansionTcpChannelTestCase.java
+++ b/nio-impl/src/test/java/org/xnio/nio/test/NioSslRandomlyTimedBufferExpansionTcpChannelTestCase.java
@@ -1,0 +1,141 @@
+/*
+ * JBoss, Home of Professional Open Source
+ *
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.xnio.nio.test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.URL;
+
+import org.junit.BeforeClass;
+import org.xnio.ChannelListener;
+import org.xnio.IoFuture;
+import org.xnio.OptionMap;
+import org.xnio.Xnio;
+import org.xnio.XnioWorker;
+import org.xnio.channels.AcceptingChannel;
+import org.xnio.channels.BoundChannel;
+import org.xnio.channels.ConnectedSslStreamChannel;
+import org.xnio.ssl.XnioSsl;
+
+/**
+ * Test for {@code XnioSsl} channel with a
+ * {@link javax.net.ssl.SSLEngineResult.Status#BUFFER_OVERFLOW} result
+ * presented at a random time.
+ * 
+ * @author <a href="mailto:frainone@redhat.com">Flavia Rainone</a>
+ *
+ */
+public class NioSslRandomlyTimedBufferExpansionTcpChannelTestCase extends AbstractNioSslTcpTest<ConnectedSslStreamChannel, ConnectedSslStreamChannel, ConnectedSslStreamChannel>{
+    private XnioSsl xnioSsl;
+    private static final String KEY_STORE_PROPERTY = "javax.net.ssl.keyStore";
+    private static final String KEY_STORE_PASSWORD_PROPERTY = "javax.net.ssl.keyStorePassword";
+    private static final String TRUST_STORE_PROPERTY = "javax.net.ssl.trustStore";
+    private static final String TRUST_STORE_PASSWORD_PROPERTY = "javax.net.ssl.trustStorePassword";
+    private static final String DEFAULT_KEY_STORE = "keystore.jks";
+    private static final String DEFAULT_KEY_STORE_PASSWORD = "jboss-remoting-test";
+
+    @Override
+    protected AcceptingChannel<? extends ConnectedSslStreamChannel> startServer(XnioWorker worker, final ChannelListener<? super ConnectedSslStreamChannel> serverHandler) throws
+            IOException {
+        AcceptingChannel<? extends ConnectedSslStreamChannel> server = super.startServer(worker, serverHandler);
+        // server atack
+        Thread thread = new Thread(() -> {
+            final Socket socket;
+            try {
+                Thread.sleep((long) (Math.random()*300));
+                socket = new Socket("127.0.0.1", SERVER_PORT);
+                OutputStream outputStream = socket.getOutputStream();
+                outputStream.write(new byte[]{0x16, 0x3, 0x3, 0x71, 0x41}, 0, 5);
+            } catch (IOException | InterruptedException e) {
+                e.printStackTrace();
+            }});
+        thread.start();
+
+        return server;
+    }
+
+    @BeforeClass
+    public static void setKeyStoreAndTrustStore() {
+        final URL storePath = NioSslTcpChannelTestCase.class.getClassLoader().getResource(DEFAULT_KEY_STORE);
+        if (System.getProperty(KEY_STORE_PROPERTY) == null) {
+            System.setProperty(KEY_STORE_PROPERTY, storePath.getFile());
+        }
+        if (System.getProperty(KEY_STORE_PASSWORD_PROPERTY) == null) {
+            System.setProperty(KEY_STORE_PASSWORD_PROPERTY, DEFAULT_KEY_STORE_PASSWORD);
+        }
+        if (System.getProperty(TRUST_STORE_PROPERTY) == null) {
+            System.setProperty(TRUST_STORE_PROPERTY, storePath.getFile());
+        }
+        if (System.getProperty(TRUST_STORE_PASSWORD_PROPERTY) == null) {
+            System.setProperty(TRUST_STORE_PASSWORD_PROPERTY, DEFAULT_KEY_STORE_PASSWORD);
+        }
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    protected AcceptingChannel<? extends ConnectedSslStreamChannel> createServer(XnioWorker worker, InetSocketAddress address,
+            ChannelListener<AcceptingChannel<ConnectedSslStreamChannel>> openListener, OptionMap optionMap) throws IOException {
+        return xnioSsl.createSslTcpServer(worker, address,  openListener,  optionMap);
+    }
+
+    @Override
+    @SuppressWarnings("deprecation")
+    protected IoFuture<? extends ConnectedSslStreamChannel> connect(XnioWorker worker, InetSocketAddress address,
+            ChannelListener<ConnectedSslStreamChannel> openListener, ChannelListener<? super BoundChannel> bindListener,
+            OptionMap optionMap) {
+        return xnioSsl.connectSsl(worker, address,  openListener, bindListener, optionMap);
+    }
+
+    @Override
+    protected void setReadListener(ConnectedSslStreamChannel channel, ChannelListener<ConnectedSslStreamChannel> readListener) {
+        channel.getReadSetter().set(readListener);
+    }
+
+    @Override
+    protected void setWriteListener(ConnectedSslStreamChannel channel, ChannelListener<ConnectedSslStreamChannel> writeListener) {
+        channel.getWriteSetter().set(writeListener);
+    }
+
+    @Override
+    protected void resumeReads(ConnectedSslStreamChannel channel) {
+        channel.resumeReads();
+    }
+
+    @Override
+    protected void resumeWrites(ConnectedSslStreamChannel channel) {
+        channel.resumeWrites();
+    }
+
+    @Override
+    protected void shutdownReads(ConnectedSslStreamChannel channel) throws IOException {
+        channel.shutdownReads();
+    }
+
+    @Override
+    protected void shutdownWrites(ConnectedSslStreamChannel channel) throws IOException {
+        channel.shutdownWrites();
+    }
+
+    @Override
+    protected void doConnectionTest(final Runnable body, final ChannelListener<? super ConnectedSslStreamChannel> clientHandler, final ChannelListener<? super ConnectedSslStreamChannel> serverHandler) throws Exception {
+        xnioSsl = Xnio.getInstance("nio", NioSslTcpChannelTestCase.class.getClassLoader()).getSslProvider(OptionMap.EMPTY);
+        super.doConnectionTest(body,  clientHandler, serverHandler);
+    }
+}

--- a/nio-impl/src/test/java/org/xnio/nio/test/NioSslRandomlyTimedBufferExpansionTcpConnectionTestCase.java
+++ b/nio-impl/src/test/java/org/xnio/nio/test/NioSslRandomlyTimedBufferExpansionTcpConnectionTestCase.java
@@ -1,0 +1,141 @@
+/*
+ * JBoss, Home of Professional Open Source
+ *
+ * Copyright 2020 Red Hat, Inc. and/or its affiliates.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.xnio.nio.test;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.net.InetSocketAddress;
+import java.net.Socket;
+import java.net.URL;
+
+import org.junit.BeforeClass;
+import org.xnio.ChannelListener;
+import org.xnio.IoFuture;
+import org.xnio.OptionMap;
+import org.xnio.Xnio;
+import org.xnio.XnioWorker;
+import org.xnio.channels.AcceptingChannel;
+import org.xnio.channels.BoundChannel;
+import org.xnio.conduits.ConduitStreamSinkChannel;
+import org.xnio.conduits.ConduitStreamSourceChannel;
+import org.xnio.ssl.SslConnection;
+import org.xnio.ssl.XnioSsl;
+
+/**
+ * Test for {@code XnioSsl} connection with a
+ * {@link javax.net.ssl.SSLEngineResult.Status#BUFFER_OVERFLOW} result
+ * presented at a random time.
+ * 
+ * @author <a href="mailto:frainone@redhat.com">Flavia Rainone</a>
+ *
+ */
+public class NioSslRandomlyTimedBufferExpansionTcpConnectionTestCase extends AbstractNioSslTcpTest<SslConnection, ConduitStreamSourceChannel, ConduitStreamSinkChannel>{
+    private XnioSsl xnioSsl;
+    private static final String KEY_STORE_PROPERTY = "javax.net.ssl.keyStore";
+    private static final String KEY_STORE_PASSWORD_PROPERTY = "javax.net.ssl.keyStorePassword";
+    private static final String TRUST_STORE_PROPERTY = "javax.net.ssl.trustStore";
+    private static final String TRUST_STORE_PASSWORD_PROPERTY = "javax.net.ssl.trustStorePassword";
+    private static final String DEFAULT_KEY_STORE = "keystore.jks";
+    private static final String DEFAULT_KEY_STORE_PASSWORD = "jboss-remoting-test";
+
+    @Override
+    protected AcceptingChannel<? extends SslConnection> startServer(XnioWorker worker, final ChannelListener<? super SslConnection> serverHandler) throws
+            IOException {
+        AcceptingChannel<? extends SslConnection> server = super.startServer(worker, serverHandler);
+        // server atack
+        Thread thread = new Thread(() -> {
+            final Socket socket;
+            try {
+                Thread.sleep((long) (Math.random()*300));
+                socket = new Socket("127.0.0.1", SERVER_PORT);
+                OutputStream outputStream = socket.getOutputStream();
+                outputStream.write(new byte[]{0x16, 0x3, 0x3, 0x71, 0x41}, 0, 5);
+            } catch (IOException | InterruptedException e) {
+                e.printStackTrace();
+            }});
+        thread.start();
+
+        return server;
+    }
+
+    @BeforeClass
+    public static void setKeyStoreAndTrustStore() {
+        final URL storePath = NioSslTcpChannelTestCase.class.getClassLoader().getResource(DEFAULT_KEY_STORE);
+        if (System.getProperty(KEY_STORE_PROPERTY) == null) {
+            System.setProperty(KEY_STORE_PROPERTY, storePath.getFile());
+        }
+        if (System.getProperty(KEY_STORE_PASSWORD_PROPERTY) == null) {
+            System.setProperty(KEY_STORE_PASSWORD_PROPERTY, DEFAULT_KEY_STORE_PASSWORD);
+        }
+        if (System.getProperty(TRUST_STORE_PROPERTY) == null) {
+            System.setProperty(TRUST_STORE_PROPERTY, storePath.getFile());
+        }
+        if (System.getProperty(TRUST_STORE_PASSWORD_PROPERTY) == null) {
+            System.setProperty(TRUST_STORE_PASSWORD_PROPERTY, DEFAULT_KEY_STORE_PASSWORD);
+        }
+    }
+
+    @Override
+    protected AcceptingChannel<? extends SslConnection> createServer(XnioWorker worker, InetSocketAddress address,
+            ChannelListener<AcceptingChannel<SslConnection>> openListener, OptionMap optionMap) throws IOException {
+        return xnioSsl.createSslConnectionServer(worker, address,  openListener,  optionMap);
+    }
+
+    @Override
+    protected IoFuture<? extends SslConnection> connect(XnioWorker worker, InetSocketAddress address,
+            ChannelListener<SslConnection> openListener, ChannelListener<? super BoundChannel> bindListener,
+            OptionMap optionMap) {
+        return xnioSsl.openSslConnection(worker, address,  openListener, bindListener, optionMap);
+    }
+
+    @Override
+    protected void setReadListener(SslConnection connection, ChannelListener<ConduitStreamSourceChannel> readListener) {
+        connection.getSourceChannel().setReadListener(readListener);
+    }
+
+    @Override
+    protected void setWriteListener(SslConnection connection, ChannelListener<ConduitStreamSinkChannel> writeListener) {
+        connection.getSinkChannel().setWriteListener(writeListener);
+    }
+
+    @Override
+    protected void resumeReads(SslConnection connection) {
+        connection.getSourceChannel().resumeReads();
+    }
+
+    @Override
+    protected void resumeWrites(SslConnection connection) {
+        connection.getSinkChannel().resumeWrites();
+    }
+
+    @Override
+    protected void shutdownReads(SslConnection connection) throws IOException {
+        connection.getSourceChannel().shutdownReads();
+    }
+
+    @Override
+    protected void shutdownWrites(SslConnection connection) throws IOException {
+        connection.getSinkChannel().shutdownWrites();
+    }
+
+    @Override
+    protected void doConnectionTest(final Runnable body, final ChannelListener<? super SslConnection> clientHandler, final ChannelListener<? super SslConnection> serverHandler) throws Exception {
+        xnioSsl = Xnio.getInstance("nio", NioSslTcpChannelTestCase.class.getClassLoader()).getSslProvider(OptionMap.EMPTY);
+        super.doConnectionTest(body,  clientHandler, serverHandler);
+    }
+}


### PR DESCRIPTION
…wrap result is BUFFER_OVERFLOW

Jira: https://issues.redhat.com/browse/XNIO-360

3.x PR: https://github.com/xnio/xnio/pull/220