### PR TITLE
[XNIO-372] NPE happens on ByteBufferSlicePool.clean() for non-direct buffers

### DIFF
--- a/api/src/main/java/org/xnio/ByteBufferSlicePool.java
+++ b/api/src/main/java/org/xnio/ByteBufferSlicePool.java
@@ -206,8 +206,11 @@ public final class ByteBufferSlicePool implements Pool<ByteBuffer> {
         if(!sliceQueue.isEmpty()) {
             sliceQueue.clear();
         }
-        // pass everything that is directly allocated to free direct buffers
-        FREE_DIRECT_BUFFERS.addAll(directBuffers);
+        // only true if using direct allocation
+        if (directBuffers != null) {
+            // pass everything that is directly allocated to free direct buffers
+            FREE_DIRECT_BUFFERS.addAll(directBuffers);
+        }
     }
 
     /**


### PR DESCRIPTION
JIRA:
- https://issues.redhat.com/browse/XNIO-372
- https://issues.redhat.com/browse/JBEAP-19049
---
3.x PR: #224 (this)
3.8 PR: #225 
3.7 PR: #226 