### PR TITLE
[XNIO-388] At terminateReads, only invoke super.terminateReads() if t…

### DIFF
--- a/api/src/main/java/org/xnio/ssl/JsseSslStreamSourceConduit.java
+++ b/api/src/main/java/org/xnio/ssl/JsseSslStreamSourceConduit.java
@@ -142,20 +142,21 @@ final class JsseSslStreamSourceConduit extends AbstractStreamSourceConduit<Strea
 
     @Override
     public void terminateReads() throws IOException {
-        if (tls) {
-            try {
-                sslEngine.closeInbound();
-            } catch (IOException ex) {
-                try {
-                    super.terminateReads();
-                } catch (IOException e2) {
-                    e2.addSuppressed(ex);
-                    throw e2;
-                }
-                throw ex;
-            }
+        if (!tls) {
+            super.terminateReads();
+            return;
         }
-        super.terminateReads();
+        try {
+            sslEngine.closeInbound();
+        } catch (IOException ex) {
+            try {
+                super.terminateReads();
+            } catch (IOException e2) {
+                e2.addSuppressed(ex);
+                throw e2;
+            }
+            throw ex;
+        }
     }
 
     @Override


### PR DESCRIPTION
…ls is false.

Invoking it when tls is enabled means that we risk closing the channel before ssl close messages can be exchanged.

Jira: https://issues.redhat.com/browse/XNIO-388
3.8 PR: #252 
