### PR TITLE
[XNIO-389] Increase the timeout of some failing blocking byte channel…

### DIFF
--- a/api/src/test/java/org/xnio/channels/AbstractBlockingReadableByteChannelTest.java
+++ b/api/src/test/java/org/xnio/channels/AbstractBlockingReadableByteChannelTest.java
@@ -278,7 +278,7 @@ public abstract class AbstractBlockingReadableByteChannelTest<T extends Scatteri
     @Test
     public void readBlocksUntilTimeoutWithBytearray5() throws Exception {
         final T blockingChannel = createBlockingReadableByteChannel(channelMock);
-        setReadTimeout(blockingChannel, 30000, TimeUnit.MICROSECONDS);
+        setReadTimeout(blockingChannel, 300000, TimeUnit.MICROSECONDS);
         final ReadToBufferArray readRunnable = new ReadToBufferArray(blockingChannel);
         final Thread readThread = new Thread(readRunnable);
         readThread.start();

--- a/api/src/test/java/org/xnio/channels/AbstractBlockingWritableByteChannelTest.java
+++ b/api/src/test/java/org/xnio/channels/AbstractBlockingWritableByteChannelTest.java
@@ -127,7 +127,7 @@ public abstract class AbstractBlockingWritableByteChannelTest<T extends Gatherin
 
     @Test
     public void writeBlocksUntilTimeout3() throws Exception {
-        final T blockingChannel = createBlockingWritableByteChannel(channelMock, 0, TimeUnit.NANOSECONDS, 30000000, TimeUnit.NANOSECONDS);
+        final T blockingChannel = createBlockingWritableByteChannel(channelMock, 0, TimeUnit.NANOSECONDS, 300000000, TimeUnit.NANOSECONDS);
         final Write writeRunnable = new Write(blockingChannel, "write... this");
         final Thread writeThread = new Thread(writeRunnable);
         writeThread.start();
@@ -305,7 +305,7 @@ public abstract class AbstractBlockingWritableByteChannelTest<T extends Gatherin
     @Test
     public void writeBufferArrayBlocksUntilTimeout5() throws Exception {
         final T blockingChannel = createBlockingWritableByteChannel(channelMock);
-        setWriteTimeout(blockingChannel, 2, TimeUnit.MICROSECONDS);
+        setWriteTimeout(blockingChannel, 20000, TimeUnit.MICROSECONDS);
         final WriteBufferArray writeRunnable = new WriteBufferArray(blockingChannel, "2", "microseconds");
         final Thread writeThread = new Thread(writeRunnable);
         writeThread.start();


### PR DESCRIPTION
… tests that were failing in CI, probably caused by slowness in a different environment

Jira: https://issues.redhat.com/browse/XNIO-389
3.8 PR: #253 