### PR TITLE
[XNIO-397] Resolve dependencies conflict

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -113,6 +113,12 @@
                 <groupId>org.wildfly.client</groupId>
                 <artifactId>wildfly-client-config</artifactId>
                 <version>${version.org.wildfly.client-config}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.wildfly.common</groupId>
+                        <artifactId>wildfly-common</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
             <dependency>
                 <groupId>org.osgi</groupId>


### PR DESCRIPTION
The module depends on wildfly-common:1.5.2.Final version. At the same time it depends on wildfly-client-config:1.0.1.Final which depends on wildfly-common:1.2.0.Final. So, the module depends on wildfly-common:1.5.2.Final directly and on wildfly-common:1.2.0.Final indirectly that leads to a conflict.
The commit/PR fixes the conflict by excluding older version from dependencies.

3.8 PR: #269 