### PR TITLE
[XNIO-392] At StreamConnection and subclasses, always shtudown reads …

### DIFF
--- a/api/src/main/java/org/xnio/StreamConnection.java
+++ b/api/src/main/java/org/xnio/StreamConnection.java
@@ -18,6 +18,7 @@
 
 package org.xnio;
 
+import java.io.IOException;
 import java.util.concurrent.atomic.AtomicReference;
 
 import org.xnio.channels.CloseListenerSettable;
@@ -78,6 +79,23 @@ public abstract class StreamConnection extends Connection implements CloseListen
             listener1.handleEvent(channel);
             listener2.handleEvent(channel);
         };
+    }
+
+    @Override protected void notifyReadClosed() {
+
+        try {
+            this.getSourceChannel().shutdownReads();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    @Override protected void notifyWriteClosed() {
+        try {
+            this.getSinkChannel().shutdownWrites();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
     }
 
     public ChannelListener<? super StreamConnection> getCloseListener() {

--- a/api/src/main/java/org/xnio/ssl/JsseSslConnection.java
+++ b/api/src/main/java/org/xnio/ssl/JsseSslConnection.java
@@ -67,10 +67,6 @@ public final class JsseSslConnection extends SslConnection {
         }
     }
 
-    protected void notifyWriteClosed() {}
-
-    protected void notifyReadClosed() {}
-
     public SocketAddress getPeerAddress() {
         return streamConnection.getPeerAddress();
     }

--- a/nio-impl/src/main/java/org/xnio/nio/NioSocketStreamConnection.java
+++ b/nio-impl/src/main/java/org/xnio/nio/NioSocketStreamConnection.java
@@ -142,10 +142,12 @@ final class NioSocketStreamConnection extends AbstractNioStreamConnection {
 
     protected void notifyWriteClosed() {
         conduit.writeTerminated();
+        super.notifyWriteClosed();
     }
 
     protected void notifyReadClosed() {
         conduit.readTerminated();
+        super.notifyReadClosed();
     }
 
     SocketChannel getChannel() {


### PR DESCRIPTION
…on source and sink channels when read and writes are closed

Jira: https://issues.redhat.com/browse/XNIO-392
3.x PR: #268 