### PR TITLE
[XNIO-398] Update JsseSslConduitEngine.java

### DIFF
--- a/api/src/main/java/org/xnio/ssl/JsseSslConduitEngine.java
+++ b/api/src/main/java/org/xnio/ssl/JsseSslConduitEngine.java
@@ -1207,7 +1207,7 @@ final class JsseSslConduitEngine {
     public boolean isDataAvailable() {
         synchronized (getUnwrapLock()) {
             try {
-                return readBuffer.getResource().hasRemaining() || (receiveBuffer.getResource().hasRemaining() && !isUnderflow());
+                return readBuffer.getResource().position() > 0 || (receiveBuffer.getResource().hasRemaining() && !isUnderflow());
             } catch (IllegalStateException ignored) {
                 return false;
             }


### PR DESCRIPTION
fix CPU busy loop when input is slow.
This is apparently same as UNDERTOW-345, and was fixed in xnio at 3.4.0.beta phase, but the problem came back after that.

3.x PR: #264 