### PR TITLE
[XNIO-403] At Channels/Conduits.drain methods, check for negative tra…

### DIFF
--- a/api/src/main/java/org/xnio/channels/Channels.java
+++ b/api/src/main/java/org/xnio/channels/Channels.java
@@ -910,7 +910,7 @@ public final class Channels {
             if (count == 0L) return total;
             if (NULL_FILE_CHANNEL != null) {
                 while (count > 0) {
-                    if ((lres = channel.transferTo(0, count, NULL_FILE_CHANNEL)) == 0L) {
+                    if ((lres = channel.transferTo(0, count, NULL_FILE_CHANNEL)) <= 0L) {
                         break;
                     }
                     total += lres;
@@ -950,7 +950,7 @@ public final class Channels {
                 if (count == 0L) return total;
                 if (NULL_FILE_CHANNEL != null) {
                     while (count > 0) {
-                        if ((lres = NULL_FILE_CHANNEL.transferFrom(channel, 0, count)) == 0L) {
+                        if ((lres = NULL_FILE_CHANNEL.transferFrom(channel, 0, count)) <= 0L) {
                             break;
                         }
                         total += lres;
@@ -990,7 +990,7 @@ public final class Channels {
             if (count == 0L) return total;
             if (NULL_FILE_CHANNEL != null) {
                 while (count > 0) {
-                    if ((lres = channel.transferTo(position, count, NULL_FILE_CHANNEL)) == 0L) {
+                    if ((lres = channel.transferTo(position, count, NULL_FILE_CHANNEL)) <= 0L) {
                         break;
                     }
                     total += lres;

--- a/api/src/main/java/org/xnio/conduits/Conduits.java
+++ b/api/src/main/java/org/xnio/conduits/Conduits.java
@@ -202,7 +202,7 @@ public final class Conduits {
             if (count == 0L) return total;
             if (NULL_FILE_CHANNEL != null) {
                 while (count > 0) {
-                    if ((lres = conduit.transferTo(0, count, NULL_FILE_CHANNEL)) == 0L) {
+                    if ((lres = conduit.transferTo(0, count, NULL_FILE_CHANNEL)) <= 0L) {
                         break;
                     }
                     total += lres;

--- a/api/src/test/java/org/xnio/channels/ChannelsTestCase.java
+++ b/api/src/test/java/org/xnio/channels/ChannelsTestCase.java
@@ -47,6 +47,7 @@ import java.nio.channels.FileChannel;
 import java.util.concurrent.TimeUnit;
 import java.util.function.LongFunction;
 
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -79,7 +80,7 @@ public class ChannelsTestCase {
         assertTrue(connectedChannelMock.isFlushed());
         connectedChannelMock.enableFlush(false);
         ByteBuffer buffer = ByteBuffer.allocate(10);
-        buffer.put("10".getBytes("UTF-8")).flip();
+        buffer.put("10".getBytes(UTF_8)).flip();
         assertEquals(2, connectedChannelMock.write(buffer));
         assertWrittenMessage(connectedChannelMock, "10");
         assertFalse(connectedChannelMock.isFlushed());
@@ -98,7 +99,7 @@ public class ChannelsTestCase {
     public void shutdownWritesBlocking() throws IOException, InterruptedException {
         connectedChannelMock.enableFlush(false);
         ByteBuffer buffer = ByteBuffer.allocate(10);
-        buffer.put("shutdown".getBytes("UTF-8")).flip();
+        buffer.put("shutdown".getBytes(UTF_8)).flip();
         assertEquals(8, connectedChannelMock.write(buffer));
         assertWrittenMessage(connectedChannelMock, "shutdown");
         assertFalse(connectedChannelMock.isShutdownWrites());
@@ -117,7 +118,7 @@ public class ChannelsTestCase {
     }
 
     @Test
-    public void writeBlocking() throws IOException, InterruptedException {
+    public void writeBlocking() throws InterruptedException {
         connectedChannelMock.enableWrite(false);
         WriteBlocking writeRunnable = new WriteBlocking(connectedChannelMock, "write this");
         Thread writeThread = new Thread(writeRunnable);
@@ -133,7 +134,7 @@ public class ChannelsTestCase {
     }
 
     @Test
-    public void writeBlockingWithTimeout() throws IOException, InterruptedException {
+    public void writeBlockingWithTimeout() throws InterruptedException {
         connectedChannelMock.enableWrite(false);
         WriteBlocking writeRunnable = new WriteBlocking(connectedChannelMock, "write with timeout", 1000, TimeUnit.MICROSECONDS);
         Thread writeThread = new Thread(writeRunnable);
@@ -149,7 +150,7 @@ public class ChannelsTestCase {
     }
 
     @Test
-    public void writeBufferArrayBlocking() throws IOException, InterruptedException {
+    public void writeBufferArrayBlocking() throws InterruptedException {
         connectedChannelMock.enableWrite(false);
         WriteBufferArrayBlocking writeRunnable = new WriteBufferArrayBlocking(connectedChannelMock, "write", " this");
         Thread writeThread = new Thread(writeRunnable);
@@ -165,7 +166,7 @@ public class ChannelsTestCase {
     }
 
     @Test
-    public void writeBufferArrayBlockingWithTimeout() throws IOException, InterruptedException {
+    public void writeBufferArrayBlockingWithTimeout() throws InterruptedException {
         connectedChannelMock.enableWrite(false);
         WriteBufferArrayBlocking writeRunnable = new WriteBufferArrayBlocking(connectedChannelMock, 1000,
                 TimeUnit.MILLISECONDS, "write", "with", "timeout");
@@ -182,7 +183,7 @@ public class ChannelsTestCase {
     }
 
     @Test
-    public void sendBlocking() throws IOException, InterruptedException {
+    public void sendBlocking() throws InterruptedException {
         connectedChannelMock.enableWrite(false);
         SendBlocking sendRunnable = new SendBlocking(messageChannelMock, "send this");
         Thread sendThread = new Thread(sendRunnable);
@@ -197,7 +198,7 @@ public class ChannelsTestCase {
     }
 
     @Test
-    public void sendBlockingWithTimeout() throws IOException, InterruptedException {
+    public void sendBlockingWithTimeout() throws InterruptedException {
         connectedChannelMock.enableWrite(false);
         SendBlocking sendRunnable = new SendBlocking(messageChannelMock, "send with timeout", 1000, TimeUnit.MICROSECONDS);
         Thread sendThread = new Thread(sendRunnable);
@@ -214,7 +215,7 @@ public class ChannelsTestCase {
     }
 
     @Test
-    public void sendBufferArrayBlocking() throws IOException, InterruptedException {
+    public void sendBufferArrayBlocking() throws InterruptedException {
         connectedChannelMock.enableWrite(false);
         SendBufferArrayBlocking sendRunnable = new SendBufferArrayBlocking(messageChannelMock, "send", " this");
         Thread sendThread = new Thread(sendRunnable);
@@ -229,7 +230,7 @@ public class ChannelsTestCase {
     }
 
     @Test
-    public void sendBufferArrayBlockingWithTimeout() throws IOException, InterruptedException {
+    public void sendBufferArrayBlockingWithTimeout() throws InterruptedException {
         connectedChannelMock.enableWrite(false);
         SendBufferArrayBlocking sendRunnable = new SendBufferArrayBlocking(messageChannelMock, 1000,
                 TimeUnit.MILLISECONDS, "send", "with", "timeout");
@@ -247,7 +248,7 @@ public class ChannelsTestCase {
     }
 
     @Test
-    public void readBlocking() throws IOException, InterruptedException {
+    public void readBlocking() throws InterruptedException {
         connectedChannelMock.setReadData("read this");
         ReadBlocking readRunnable = new ReadBlocking(connectedChannelMock);
         Thread readThread = new Thread(readRunnable);
@@ -263,7 +264,7 @@ public class ChannelsTestCase {
     }
 
     @Test
-    public void readBlockingToEmptyBuffer() throws IOException, InterruptedException {
+    public void readBlockingToEmptyBuffer() throws InterruptedException {
         connectedChannelMock.setReadData("can't read this");
         ReadBlocking readRunnable = new ReadBlocking(connectedChannelMock, Buffers.EMPTY_BYTE_BUFFER);
         Thread readThread = new Thread(readRunnable);
@@ -274,7 +275,7 @@ public class ChannelsTestCase {
     }
 
     @Test
-    public void readBlockingWithTimeout() throws IOException, InterruptedException {
+    public void readBlockingWithTimeout() throws InterruptedException {
         connectedChannelMock.setReadData("read with timeout");
         ReadBlocking readRunnable = new ReadBlocking(connectedChannelMock, 100, TimeUnit.MILLISECONDS);
         Thread readThread = new Thread(readRunnable);
@@ -290,7 +291,7 @@ public class ChannelsTestCase {
     }
 
     @Test
-    public void readBlockingWithTimeoutToEmptyBuffer() throws IOException, InterruptedException {
+    public void readBlockingWithTimeoutToEmptyBuffer() throws InterruptedException {
         connectedChannelMock.setReadData("can't read this");
         ReadBlocking readRunnable = new ReadBlocking(connectedChannelMock, 100, TimeUnit.MILLISECONDS, Buffers.EMPTY_BYTE_BUFFER);
         Thread readThread = new Thread(readRunnable);
@@ -305,7 +306,7 @@ public class ChannelsTestCase {
     }
 
     @Test
-    public void readBlockingToBufferArray() throws IOException, InterruptedException {
+    public void readBlockingToBufferArray() throws InterruptedException {
         connectedChannelMock.setReadData("read", "this");
         ReadToBufferArrayBlocking readRunnable = new ReadToBufferArrayBlocking(connectedChannelMock);
         Thread readThread = new Thread(readRunnable);
@@ -325,7 +326,7 @@ public class ChannelsTestCase {
     }
 
     @Test
-    public void readBlockingToBufferArrayWithTimeout() throws IOException, InterruptedException {
+    public void readBlockingToBufferArrayWithTimeout() throws InterruptedException {
         connectedChannelMock.setReadData("read", "with", "timeout");
         ReadToBufferArrayBlocking readRunnable = new ReadToBufferArrayBlocking(connectedChannelMock, 1000,
                 TimeUnit.MILLISECONDS);
@@ -346,13 +347,13 @@ public class ChannelsTestCase {
     }
 
     @Test
-    public void readBlockingToEmptyBufferArrayWithTimeout() throws IOException, InterruptedException {
+    public void readBlockingToEmptyBufferArrayWithTimeout() throws IOException {
         connectedChannelMock.setReadData("can't read this");
         assertEquals(0, Channels.readBlocking(connectedChannelMock, new ByteBuffer[0], 0, 0, 2, TimeUnit.MINUTES));
     }
 
     @Test
-    public void receiveBlocking() throws IOException, InterruptedException {
+    public void receiveBlocking() throws InterruptedException {
         connectedChannelMock.setReadData("receive this");
         ReceiveBlocking receiveRunnable = new ReceiveBlocking(messageChannelMock);
         Thread receiveThread = new Thread(receiveRunnable);
@@ -368,7 +369,7 @@ public class ChannelsTestCase {
     }
 
     @Test
-    public void receiveBlockingWithTimeout() throws IOException, InterruptedException {
+    public void receiveBlockingWithTimeout() throws InterruptedException {
         connectedChannelMock.setReadData("receive with timeout");
         ReceiveBlocking receiveRunnable = new ReceiveBlocking(messageChannelMock, 100, TimeUnit.MILLISECONDS);
         Thread receiveThread = new Thread(receiveRunnable);
@@ -384,7 +385,7 @@ public class ChannelsTestCase {
     }
 
     @Test
-    public void receiveBufferArrayBlocking() throws IOException, InterruptedException {
+    public void receiveBufferArrayBlocking() throws InterruptedException {
         connectedChannelMock.setReadData("receive", "this");
         ReceiveBufferArrayBlocking receiveRunnable = new ReceiveBufferArrayBlocking(messageChannelMock);
         Thread receiveThread = new Thread(receiveRunnable);
@@ -404,7 +405,7 @@ public class ChannelsTestCase {
     }
 
     @Test
-    public void receiveBufferArrayBlockingWithTimeout() throws IOException, InterruptedException {
+    public void receiveBufferArrayBlockingWithTimeout() throws InterruptedException {
         connectedChannelMock.setReadData("receive", "with", "timeout");
         ReceiveBufferArrayBlocking receiveRunnable = new ReceiveBufferArrayBlocking(messageChannelMock, 1000,
                 TimeUnit.MILLISECONDS);
@@ -427,7 +428,7 @@ public class ChannelsTestCase {
     @Test
     public void acceptBlocking() throws IOException, InterruptedException {
         final AcceptingChannelMock acceptingChannelMock = new AcceptingChannelMock();
-        final AcceptBlocking<?> acceptBlockingRunnable = new AcceptBlocking<StreamConnection>(acceptingChannelMock);
+        final AcceptBlocking<?> acceptBlockingRunnable = new AcceptBlocking<>(acceptingChannelMock);
         final Thread acceptChannelThread = new Thread(acceptBlockingRunnable);
         assertNotNull(Channels.acceptBlocking(acceptingChannelMock));
         assertFalse(acceptingChannelMock.haveWaitedAcceptable());
@@ -447,7 +448,7 @@ public class ChannelsTestCase {
     @Test
     public void acceptBlockingWithTimeout() throws IOException, InterruptedException {
         final AcceptingChannelMock acceptingChannelMock = new AcceptingChannelMock();
-        final AcceptBlocking<?> acceptBlockingRunnable = new AcceptBlocking<StreamConnection>(acceptingChannelMock, 10, TimeUnit.SECONDS);
+        final AcceptBlocking<?> acceptBlockingRunnable = new AcceptBlocking<>(acceptingChannelMock, 10, TimeUnit.SECONDS);
         final Thread acceptChannelThread = new Thread(acceptBlockingRunnable);
         // try to accept blocking with acceptance enabled at accepting channel mock
         assertNotNull(Channels.acceptBlocking(acceptingChannelMock, 1, TimeUnit.SECONDS));
@@ -457,7 +458,7 @@ public class ChannelsTestCase {
         acceptChannelThread.start();
         acceptChannelThread.join(200);
         assertFalse(acceptChannelThread.isAlive());
-        // thread is supposed to have finished, after having invoked awaitAcceptable at acceptingchannelMock with 10s timeout
+        // thread is supposed to have finished, after having invoked awaitAcceptable at acceptingChannelMock with 10s timeout
         assertTrue(acceptingChannelMock.haveWaitedAcceptable());
         assertEquals(10, acceptingChannelMock.getAwaitAcceptableTime());
         assertEquals(TimeUnit.SECONDS, acceptingChannelMock.getAwaitAcceptableTimeUnit());
@@ -525,7 +526,7 @@ public class ChannelsTestCase {
         final FileChannel fileChannel = randomAccessFile.getChannel();
         try {
             final ByteBuffer buffer = ByteBuffer.allocate(10);
-            buffer.put("test".getBytes("UTF-8")).flip();
+            buffer.put("test".getBytes(UTF_8)).flip();
             assertEquals(4, fileChannel.write(buffer));
             fileChannel.position(0);
             Channels.transferBlocking(channelMock, fileChannel, 0, 4);
@@ -546,7 +547,7 @@ public class ChannelsTestCase {
         final FileChannel fileChannel = randomAccessFile.getChannel();
         try {
             final ByteBuffer buffer = ByteBuffer.allocate(10);
-            buffer.put("test12345".getBytes("UTF-8")).flip();
+            buffer.put("test12345".getBytes(UTF_8)).flip();
             assertEquals(9, fileChannel.write(buffer));
             fileChannel.position(0);
             
@@ -566,9 +567,7 @@ public class ChannelsTestCase {
     @Test
     public void setChannelListeners() {
         final ConnectedStreamChannelMock channelMock = new ConnectedStreamChannelMock();
-        final ChannelListener<ConnectedStreamChannel> channelListener = new ChannelListener<ConnectedStreamChannel>() {
-            public void handleEvent(final ConnectedStreamChannel channel) {}
-        };
+        final ChannelListener<ConnectedStreamChannel> channelListener = channel -> {};
 
         // test setReadListener
         Channels.setReadListener(channelMock, channelListener);
@@ -592,9 +591,7 @@ public class ChannelsTestCase {
     @Test
     public void setAcceptListener() {
         final AcceptingChannelMock channelMock = new AcceptingChannelMock();
-        final ChannelListener<AcceptingChannel<StreamConnection>> channelListener = new ChannelListener<AcceptingChannel<StreamConnection>>() {
-            public void handleEvent(final AcceptingChannel<StreamConnection> channel) {}
-        };
+        final ChannelListener<AcceptingChannel<StreamConnection>> channelListener = channel -> {};
 
         Channels.setAcceptListener(channelMock, channelListener);
         assertSame(channelListener, channelMock.getAcceptListener());
@@ -639,16 +636,16 @@ public class ChannelsTestCase {
         assertReadMessage(bufferArray[5]);
         // test write(ByteBuffer)
         buffer.clear();
-        buffer.put("write".getBytes("UTF-8")).flip();
+        buffer.put("write".getBytes(UTF_8)).flip();
         wrappedByteChannel.write(buffer);
         assertWrittenMessage(channelMock, "write");
         // test write(ByteBuffer[])
         for(ByteBuffer bufferItem: bufferArray) {
             bufferItem.clear();
         }
-        bufferArray[0].put("writ".getBytes("UTF-8")).flip();
-        bufferArray[1].put("e_ag".getBytes("UTF-8")).flip();
-        bufferArray[2].put("ain".getBytes("UTF-8")).flip();
+        bufferArray[0].put("writ".getBytes(UTF_8)).flip();
+        bufferArray[1].put("e_ag".getBytes(UTF_8)).flip();
+        bufferArray[2].put("ain".getBytes(UTF_8)).flip();
         bufferArray[3].flip();
         bufferArray[4].flip();
         bufferArray[5].flip();
@@ -702,13 +699,14 @@ public class ChannelsTestCase {
         assertEquals(1000, Channels.getOption(channelMock, Options.MAX_OUTBOUND_MESSAGE_SIZE, 1000));
         assertEquals(5000, Channels.getOption(brokenConfigurable, Options.SSL_CLIENT_SESSION_TIMEOUT, 5000));
         // long type option
-        assertEquals(1l, Channels.getOption(channelMock, Options.STACK_SIZE, 1l));
-        channelMock.setOption(Options.STACK_SIZE, 50000l);
-        assertEquals(50000l, Channels.getOption(channelMock, Options.STACK_SIZE, 100));
+        assertEquals(1L, Channels.getOption(channelMock, Options.STACK_SIZE, 1L));
+        channelMock.setOption(Options.STACK_SIZE, 50000L);
+        assertEquals(50000L, Channels.getOption(channelMock, Options.STACK_SIZE, 100));
         assertEquals(100, Channels.getOption(brokenConfigurable, Options.STACK_SIZE, 100));
     }
 
     @Test
+    @SuppressWarnings( "deprecation" )
     public void unwrap() {
         assertNull(Channels.unwrap(ConnectedStreamChannelMock.class, null));
         final ConnectedStreamChannelMock channelMock = new ConnectedStreamChannelMock();
@@ -826,12 +824,12 @@ public class ChannelsTestCase {
         assertTrue(failed);
     }
 
-    private void assertDrain(ReadableByteChannelMock channelMock, LongFunction drainFunction) throws IOException {
+    private void assertDrain(ReadableByteChannelMock channelMock, LongFunction<Long> drainFunction) throws IOException {
         channelMock.enableClosedCheck(true);
         // test drain 0
         channelMock.setReadData("read", "data");
         channelMock.enableRead(true);
-        assertEquals(0l, drainFunction.apply(0));
+        assertEquals(0L, (long) drainFunction.apply(0));
         ByteBuffer buffer = ByteBuffer.allocate(10);
         channelMock.read(buffer);
         assertReadMessage(buffer, "read", "data");
@@ -853,7 +851,7 @@ public class ChannelsTestCase {
         // test drain 2
         channelMock.setReadData("read", "data");
         channelMock.enableRead(true);
-        assertEquals(2l, drainFunction.apply(2));
+        assertEquals(2L, (long) drainFunction.apply(2));
         buffer.clear();
         assertEquals(6, channelMock.read(buffer));
         assertReadMessage(buffer, "ad", "data");
@@ -862,9 +860,9 @@ public class ChannelsTestCase {
         channelMock.setReadData("read", "data");
         channelMock.enableRead(true);
         buffer.clear();
-        assertEquals(1l, drainFunction.apply(1));
-        assertEquals(2l, drainFunction.apply(2));
-        assertEquals(3l, drainFunction.apply(3));
+        assertEquals(1L, (long) drainFunction.apply(1));
+        assertEquals(2L, (long) drainFunction.apply(2));
+        assertEquals(3L, (long) drainFunction.apply(3));
         assertEquals(2, channelMock.read(buffer));
         assertReadMessage(buffer, "ta");
 
@@ -872,14 +870,14 @@ public class ChannelsTestCase {
         channelMock.setReadData("read", "data");
         channelMock.enableRead(true);
         buffer.clear();
-        assertEquals(8l, drainFunction.apply(8));
+        assertEquals(8L, (long) drainFunction.apply(8));
         assertEquals(0, channelMock.read(buffer));
 
         // test drain more bytes than available
         channelMock.setReadData("read", "data");
         channelMock.enableRead(true);
         buffer.clear();
-        assertEquals(8l, drainFunction.apply(9));
+        assertEquals(8L, (long) drainFunction.apply(9));
         assertEquals(0, channelMock.read(buffer));
 
         // test drain the exact amount of bytes left without reading the EOF
@@ -887,25 +885,25 @@ public class ChannelsTestCase {
         channelMock.enableRead(true);
         channelMock.setEof();
         buffer.clear();
-        assertEquals(8l, drainFunction.apply(8));
+        assertEquals(8L, (long) drainFunction.apply(8));
         assertEquals(-1, channelMock.read(buffer));
 
         // test drain more bytes than available with eof
         channelMock.setReadData("read", "data");
         channelMock.enableRead(true);
         buffer.clear();
-        assertEquals(8l, drainFunction.apply(9));
+        assertEquals(8L, (long) drainFunction.apply(9));
         assertEquals(-1, channelMock.read(buffer));
 
         // test drain with long max (Undertow usage)
         channelMock.setReadData("read", "data");
         channelMock.enableRead(true);
         buffer.clear();
-        assertEquals(8l, drainFunction.apply(Long.MAX_VALUE));
+        assertEquals(8L, (long) drainFunction.apply(Long.MAX_VALUE));
         assertEquals(-1, channelMock.read(buffer));
 
         // test drain an already drained channel
-        assertEquals(-1l, drainFunction.apply(Long.MAX_VALUE));
+        assertEquals(-1L, (long) drainFunction.apply(Long.MAX_VALUE));
         assertEquals(-1, channelMock.read(buffer));
 
         channelMock.close();
@@ -976,7 +974,7 @@ public class ChannelsTestCase {
         public void run() {
             ByteBuffer buffer = ByteBuffer.allocate(30);
             try {
-                buffer.put(message.getBytes("UTF-8")).flip();
+                buffer.put(message.getBytes(UTF_8)).flip();
                 if (timeoutUnit != null) {
                     writeResult = Channels.writeBlocking(channel, buffer, timeout, timeoutUnit);
                 } else {
@@ -1016,7 +1014,7 @@ public class ChannelsTestCase {
             try {
                 for (int i = 0; i < buffer.length; i++) {
                     buffer[i] = ByteBuffer.allocate(message[i].length());
-                    buffer[i].put(message[i].getBytes("UTF-8")).flip();
+                    buffer[i].put(message[i].getBytes(UTF_8)).flip();
                 }
                 if (timeoutUnit != null) {
                     writeResult = Channels.writeBlocking(channel, buffer, 0, buffer.length, timeout, timeoutUnit);
@@ -1055,7 +1053,7 @@ public class ChannelsTestCase {
         public void run() {
             ByteBuffer buffer = ByteBuffer.allocate(30);
             try {
-                buffer.put(message.getBytes("UTF-8")).flip();
+                buffer.put(message.getBytes(UTF_8)).flip();
                 if (timeoutUnit != null) {
                     sendResult = Channels.sendBlocking(channel, buffer, timeout, timeoutUnit);
                 } else {
@@ -1095,7 +1093,7 @@ public class ChannelsTestCase {
             try {
                 for (int i = 0; i < buffer.length; i++) {
                     buffer[i] = ByteBuffer.allocate(message[i].length());
-                    buffer[i].put(message[i].getBytes("UTF-8")).flip();
+                    buffer[i].put(message[i].getBytes(UTF_8)).flip();
                 }
                 if (timeoutUnit != null) {
                     sendResult = Channels.sendBlocking(channel, buffer, 0, buffer.length, timeout, timeoutUnit);

--- a/api/src/test/java/org/xnio/mock/ReadableByteChannelMock.java
+++ b/api/src/test/java/org/xnio/mock/ReadableByteChannelMock.java
@@ -1,0 +1,217 @@
+/*
+ * JBoss, Home of Professional Open Source.
+ *
+ * Copyright 2022 Red Hat, Inc. and/or its affiliates, and individual
+ * contributors as indicated by the @author tags.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.xnio.mock;
+
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ClosedChannelException;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.charset.StandardCharsets;
+
+import org.xnio.Buffers;
+
+/**
+ * Mock of a connected stream channel.<p>
+ * This channel mock will store everything that is written to it for later comparison, and allows feeding of bytes for
+ * reading.
+ * 
+ * @author <a href="mailto:flavia.rainone@jboss.com">Flavia Rainone</a>
+ */
+public class ReadableByteChannelMock implements ReadableByteChannel {
+
+    // read stuff will be taken from this buffer
+    protected ByteBuffer readBuffer = ByteBuffer.allocate(10000);
+    // read stuff can only be read if read is enabled
+    protected boolean readEnabled;
+    // indicates if this channel is closed
+    protected boolean closed = false;
+    protected boolean checkClosed = true;
+    protected boolean eof = false;
+
+    /**
+     * Feeds {@code readData} to read clients.
+     * @param readData data that will be available for reading on this channel mock
+     */
+    public void setReadData(String... readData) {
+        doSetReadData(readData);
+    }
+
+    protected synchronized int doSetReadData(String... readData) {
+        int totalLength = 0;
+        for (String data: readData) {
+            totalLength += data.length();
+        }
+        int position = readBuffer.position();
+        boolean resetPosition = false;
+        if (!readBuffer.hasRemaining()) {
+            readBuffer.compact();
+        } else if(readBuffer.position() > 0 || readBuffer.limit() != readBuffer.capacity()) {
+            if (readBuffer.capacity() - readBuffer.limit() < totalLength) {
+                if (readBuffer.position() > 0 && readBuffer.capacity() - readBuffer.limit() + readBuffer.position() >= totalLength) {
+                    readBuffer.compact();
+                }
+                throw new RuntimeException("ReadBuffer is full - not enough space to add more read data");
+            }
+            int limit = readBuffer.limit();
+            readBuffer.position(limit);
+            readBuffer.limit(limit + totalLength);
+            resetPosition = true;
+        }
+        for (String data: readData) {
+            readBuffer.put(data.getBytes(StandardCharsets.UTF_8));
+        }
+        readBuffer.flip();
+        if (resetPosition) {
+            readBuffer.position(position);
+        }
+        return totalLength;
+    }
+
+    /**
+     * Feeds {@code readData} to read clients.
+     * @param readData data that will be available for reading on this channel mock
+     */
+    public void setReadDataWithLength(String... readData) {
+        doSetReadDataWithLength(readData);
+    }
+
+    protected synchronized int doSetReadDataWithLength(String... readData) {
+        if (eof) {
+            throw new IllegalStateException("Cannot add read data once eof is set");
+        }
+        int totalLength = 0;
+        for (String data: readData) {
+            totalLength += data.length();
+        }
+        int position = readBuffer.position();
+        boolean resetPosition = false;
+        if (!readBuffer.hasRemaining()) {
+            readBuffer.compact();
+        } else if(readBuffer.position() > 0 || readBuffer.limit() != readBuffer.capacity()) {
+            if (readBuffer.capacity() - readBuffer.limit() + 4 < totalLength) {
+                if (readBuffer.position() > 0 && readBuffer.capacity() - readBuffer.limit() + readBuffer.position() + 4 >= totalLength) {
+                    readBuffer.compact();
+                }
+                throw new RuntimeException("ReadBuffer is full - not enough space to add more read data");
+            }
+            int limit = readBuffer.limit();
+            readBuffer.position(limit);
+            readBuffer.limit(limit + totalLength + 4);
+            resetPosition = true;
+        }
+        readBuffer.putInt(totalLength);
+        for (String data: readData) {
+            readBuffer.put(data.getBytes(StandardCharsets.UTF_8));
+        }
+        readBuffer.flip();
+        if (resetPosition) {
+            readBuffer.position(position);
+        }
+        return totalLength;
+    }
+
+    /**
+     * Feeds {@code readData} to read clients.
+     * @param readData data that will be available for reading on this channel mock
+     */
+    public void setReadDataWithLength(int length, String... readData) {
+        doSetReadDataWithLength(length, readData);
+    }
+
+    protected synchronized int doSetReadDataWithLength(int length, String... readData) {
+        if (eof) {
+            throw new IllegalStateException("Cannot add read data once eof is set");
+        }
+        int totalLength = 0;
+        for (String data: readData) {
+            totalLength += data.length();
+        }
+        int position = readBuffer.position();
+        boolean resetPosition = false;
+        if (!readBuffer.hasRemaining()) {
+            readBuffer.compact();
+        } else if(readBuffer.position() > 0 || readBuffer.limit() != readBuffer.capacity()) {
+            if (readBuffer.capacity() - readBuffer.limit() + 4 < totalLength) {
+                if (readBuffer.position() > 0 && readBuffer.capacity() - readBuffer.limit() + readBuffer.position() + 4 >= totalLength) {
+                    readBuffer.compact();
+                }
+                throw new RuntimeException("ReadBuffer is full - not enough space to add more read data");
+            }
+            int limit = readBuffer.limit();
+            readBuffer.position(limit);
+            readBuffer.limit(limit + totalLength + 4);
+            resetPosition = true;
+        }
+        readBuffer.putInt(length);
+        for (String data: readData) {
+            readBuffer.put(data.getBytes(StandardCharsets.UTF_8));
+        }
+        readBuffer.flip();
+        if (resetPosition) {
+            readBuffer.position(position);
+        }
+        return totalLength;
+    }
+
+    public synchronized void setEof() {
+        eof = true;
+    }
+
+    public synchronized void enableRead(boolean enable) {
+        readEnabled = enable;
+    }
+
+    public synchronized void enableClosedCheck(boolean enable) {
+        checkClosed = enable;
+    }
+
+    @Override
+    public void close() throws IOException {
+        closed = true;
+    }
+
+    @Override
+    public boolean isOpen() {
+        return !closed;
+    }
+
+    @Override
+    public synchronized int read(ByteBuffer dst) throws IOException {
+        if (closed && checkClosed) {
+            throw new ClosedChannelException();
+        }
+        if (readEnabled) {
+            try {
+                if ((!readBuffer.hasRemaining() || readBuffer.position() == 0 && readBuffer.limit() == readBuffer.capacity()) && eof) {
+                    return -1;
+                }
+                if (readBuffer.limit() == readBuffer.capacity() && readBuffer.position() == 0) {
+                    return 0;
+                }
+                return Buffers.copy(dst, readBuffer);
+            } catch (RuntimeException e) {
+                System.out.println("Got exception at attempt of copying contents of dst "+ dst.remaining()  +  " into read buffer " + readBuffer.remaining());
+                throw e;
+            }
+        }
+        return 0;
+    }
+}


### PR DESCRIPTION
…nsfer results.

Also, add tests for Channels.drain methods at ChannelsTestCase.

Signed-off-by: Flavia Rainone <frainone@redhat.com>

Jira: https://issues.redhat.com/browse/XNIO-403
3.8 PR: #288 