### PR TITLE
[XNIO-401] CVE 2022-0084 At StreamConnection.notifyRead/WriteClosed()…

### DIFF
--- a/api/src/main/java/org/xnio/StreamConnection.java
+++ b/api/src/main/java/org/xnio/StreamConnection.java
@@ -88,7 +88,7 @@ public abstract class StreamConnection extends Connection implements CloseListen
         try {
             this.getSourceChannel().shutdownReads();
         } catch (IOException e) {
-            log.error("Error in read close", e);
+            msg.connectionNotifyReadClosedFailed(e, this);
         }
     }
 
@@ -96,7 +96,7 @@ public abstract class StreamConnection extends Connection implements CloseListen
         try {
             this.getSinkChannel().shutdownWrites();
         } catch (IOException e) {
-            log.error("Error in write close", e);
+            msg.connectionNotifyWriteClosedFailed(e, this);
         }
     }
 

--- a/api/src/main/java/org/xnio/_private/Messages.java
+++ b/api/src/main/java/org/xnio/_private/Messages.java
@@ -43,6 +43,7 @@ import org.jboss.logging.annotations.LogMessage;
 import org.jboss.logging.annotations.Message;
 import org.jboss.logging.annotations.MessageLogger;
 import org.xnio.IoFuture;
+import org.xnio.StreamConnection;
 import org.xnio.channels.AcceptingChannel;
 import org.xnio.channels.ConcurrentStreamChannelAccessException;
 import org.xnio.channels.ConnectedChannel;
@@ -361,4 +362,12 @@ public interface Messages extends BasicLogger {
     @Message(value = "Expanded buffer enabled due to overflow with empty buffer, expanded buffer size is %s")
     @LogMessage(level = TRACE)
     void expandedSslBufferEnabled(int bufferSize);
+
+    @Message(value = "Notify read closed for connection %s failed")
+    @LogMessage(level = TRACE)
+    void connectionNotifyReadClosedFailed(@Cause Throwable cause, StreamConnection connection);
+
+    @Message(value = "Notify write closed for connection %s failed")
+    @LogMessage(level = TRACE)
+    void connectionNotifyWriteClosedFailed(@Cause Throwable cause, StreamConnection connection);
 }


### PR DESCRIPTION
… methods, move the error log messages to tracing.

This prevents the log file to be filled with error messages caused by external factors to the server.

Jira: https://issues.redhat.com/browse/XNIO-401

3.8 PR: #292 