### PR TITLE
[XNIO-415] WatchServiceFileSystemWatcher swallows some events

### DIFF
--- a/nio-impl/src/main/java/org/xnio/nio/WatchServiceFileSystemWatcher.java
+++ b/nio-impl/src/main/java/org/xnio/nio/WatchServiceFileSystemWatcher.java
@@ -117,7 +117,6 @@ class WatchServiceFileSystemWatcher implements FileSystemWatcher, Runnable {
                                 }
                                 results.add(new FileChangeEvent(targetFile, type));
                             }
-                            key.pollEvents().clear();
 
                             //now we need to prune the results, to remove duplicates
                             //e.g. if the file is modified after creation we only want to


### PR DESCRIPTION
Issue: https://issues.redhat.com/browse/XNIO-415

The `clear` in `WatchServiceFileSystemWatcher` is causing havoc and losing events. The [API](https://docs.oracle.com/en/java/javase/11/docs/api/java.base/java/nio/file/WatchKey.html) says that you just need to read the events and do a reset after that. The test ensures that adds are missing when the clear is in place.

PR for 3.x branch.
PR for 3.8: https://github.com/xnio/xnio/pull/295