### PR TITLE
feat: change threadName separator from whitespace to :

### DIFF
--- a/api/src/main/java/org/xnio/XnioWorker.java
+++ b/api/src/main/java/org/xnio/XnioWorker.java
@@ -1284,7 +1284,7 @@ public abstract class XnioWorker extends AbstractExecutorService implements Conf
                                 xnio.handleThreadExit();
                             }
                         }
-                    }, name + " task-" + getNextSeq(), stackSize);
+                    }, name + ":task-" + getNextSeq(), stackSize);
                     // Mark the thread as daemon if the Options.THREAD_DAEMON has been set
                     if (markThreadAsDaemon) {
                         taskThread.setDaemon(true);

--- a/nio-impl/src/main/java/org/xnio/nio/NioXnioWorker.java
+++ b/nio-impl/src/main/java/org/xnio/nio/NioXnioWorker.java
@@ -99,7 +99,7 @@ final class NioXnioWorker extends XnioWorker {
                 } catch (IOException e) {
                     throw Log.log.unexpectedSelectorOpenProblem(e);
                 }
-                final WorkerThread workerThread = new WorkerThread(this, threadSelector, String.format("%s I/O-%d", workerName, Integer.valueOf(i + 1)), threadGroup, workerStackSize, i);
+                final WorkerThread workerThread = new WorkerThread(this, threadSelector, String.format("%s:I/O-%d", workerName, Integer.valueOf(i + 1)), threadGroup, workerStackSize, i);
                 // Mark as daemon if the Options.THREAD_DAEMON has been set
                 if (markWorkerThreadAsDaemon) {
                     workerThread.setDaemon(true);
@@ -112,7 +112,7 @@ final class NioXnioWorker extends XnioWorker {
             } catch (IOException e) {
                 throw Log.log.unexpectedSelectorOpenProblem(e);
             }
-            acceptThread = new WorkerThread(this, threadSelector, String.format("%s Accept", workerName), threadGroup, workerStackSize, threadCount);
+            acceptThread = new WorkerThread(this, threadSelector, String.format("%s:Accept", workerName), threadGroup, workerStackSize, threadCount);
             if (markWorkerThreadAsDaemon) {
                 acceptThread.setDaemon(true);
             }


### PR DESCRIPTION
thredName should not have whitespace
In most logging layout.ConversionPattern whitespace was a field separator, so if the thredName with whitespace, then then fields was not fixed it's not friendly for logging sort , ie: sort `-rnk $N`