### PR TITLE
[XNIO-385] Ensure that the close method waits until the server key ca…

### DIFF
--- a/nio-impl/src/main/java/org/xnio/nio/NioTcpServer.java
+++ b/nio-impl/src/main/java/org/xnio/nio/NioTcpServer.java
@@ -258,7 +258,7 @@ final class NioTcpServer extends AbstractNioChannel<NioTcpServer> implements Acc
             channel.close();
         } finally {
             for (NioTcpServerHandle handle : handles) {
-                handle.cancelKey(false);
+                handle.cancelKey(true);
             }
             safeClose(mbeanHandle);
         }


### PR DESCRIPTION
…ncellation releases the resources

Follows up on #248 which was closed due to CI issues. However, I'm unable to see the issues again, and WildFly and WildFly Core testsuite pass with 3.8.x plus this patch.


Jira issue: https://issues.redhat.com/browse/XNIO-385
3.x PR: #310
3.9 PR: #325 

CC @fl4via 