### PR TITLE
[XNIO-429] Require JDK11 and above since now on

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,14 +9,14 @@ on:
 
 jobs:
   build-all:
-    name: Compile (no tests) with JDK 8
+    name: Compile (no tests) with JDK 11
     runs-on: ubuntu-latest
     steps:
     - uses: actions/checkout@v2
     - uses: AdoptOpenJDK/install-jdk@v1
-      name: Install JDK 8
+      name: Install JDK 11
       with:
-        version: 8    
+        version: 11
     - name: Build
       run: mvn -U -B -fae -DskipTests clean install
     - name: Tar Maven Repo
@@ -41,7 +41,7 @@ jobs:
       matrix:
         module: [api, nio-impl]
         os: [ubuntu-20.04, windows-latest, macos-latest]
-        jdk: [8, 11, 17, 21]
+        jdk: [11, 17, 21]
         openjdk_impl: [hotspot, openj9]
         exclude:
           - os: macos-latest

--- a/nio-impl/src/main/java/org/xnio/nio/NioXnio.java
+++ b/nio-impl/src/main/java/org/xnio/nio/NioXnio.java
@@ -75,8 +75,6 @@ final class NioXnio extends Xnio {
         final Object[] objects = AccessController.doPrivileged(
             new PrivilegedAction<Object[]>() {
                 public Object[] run() {
-                    String jdkVersion = System.getProperty("java.specification.version", "1.8");
-                    final boolean jdk9 = ! (jdkVersion.equals("1.8") || jdkVersion.equals("8"));
                     final SelectorProvider defaultProvider = SelectorProvider.provider();
                     final String chosenProvider = System.getProperty("xnio.nio.selector.provider");
                     SelectorProvider provider = null;
@@ -87,69 +85,6 @@ final class NioXnio extends Xnio {
                         } catch (Throwable e) {
                             // not available
                             provider = null;
-                        }
-                    }
-                    if (! jdk9) {
-                        // try to probe the best available provider
-                        if (provider == null) {
-                            try {
-                                // Mac OS X and BSD
-                                provider = Class.forName("sun.nio.ch.KQueueSelectorProvider", true, NioXnio.class.getClassLoader()).asSubclass(SelectorProvider.class).getConstructor().newInstance();
-                                provider.openSelector().close();
-                            } catch (Throwable e) {
-                                // not available
-                                provider = null;
-                            }
-                        }
-                        if (provider == null) {
-                            try {
-                                // Linux
-                                provider = Class.forName("sun.nio.ch.EPollSelectorProvider", true, NioXnio.class.getClassLoader()).asSubclass(SelectorProvider.class).getConstructor().newInstance();
-                                provider.openSelector().close();
-                            } catch (Throwable e) {
-                                // not available
-                                provider = null;
-                            }
-                        }
-                        if (provider == null && ! HAS_BUGGY_EVENT_PORT) {
-                            try {
-                                // Solaris (Java 8+)
-                                provider = Class.forName("sun.nio.ch.EventPortSelectorProvider", true, NioXnio.class.getClassLoader()).asSubclass(SelectorProvider.class).getConstructor().newInstance();
-                                provider.openSelector().close();
-                            } catch (Throwable e) {
-                                // not available
-                                provider = null;
-                            }
-                        }
-                        if (provider == null) {
-                            try {
-                                // Solaris
-                                provider = Class.forName("sun.nio.ch.DevPollSelectorProvider", true, NioXnio.class.getClassLoader()).asSubclass(SelectorProvider.class).getConstructor().newInstance();
-                                provider.openSelector().close();
-                            } catch (Throwable e) {
-                                // not available
-                                provider = null;
-                            }
-                        }
-                        if (provider == null) {
-                            try {
-                                // Solaris (Java 8+)
-                                provider = Class.forName("sun.nio.ch.EventPortSelectorProvider", true, NioXnio.class.getClassLoader()).asSubclass(SelectorProvider.class).getConstructor().newInstance();
-                                provider.openSelector().close();
-                            } catch (Throwable e) {
-                                // not available
-                                provider = null;
-                            }
-                        }
-                        if (provider == null) {
-                            try {
-                                // AIX
-                                provider = Class.forName("sun.nio.ch.PollsetSelectorProvider", true, NioXnio.class.getClassLoader()).asSubclass(SelectorProvider.class).getConstructor().newInstance();
-                                provider.openSelector().close();
-                            } catch (Throwable e) {
-                                // not available
-                                provider = null;
-                            }
                         }
                     }
                     if (provider == null) {
@@ -174,7 +109,6 @@ final class NioXnio extends Xnio {
                         throw log.noSelectorProvider();
                     }
                     log.selectorProvider(provider);
-                    final boolean defaultIsPoll = "sun.nio.ch.PollSelectorProvider".equals(provider.getClass().getName());
                     final String chosenMainSelector = System.getProperty("xnio.nio.selector.main");
                     final String chosenTempSelector = System.getProperty("xnio.nio.selector.temp");
                     final SelectorCreator defaultSelectorCreator = new DefaultSelectorCreator(provider);
@@ -193,16 +127,6 @@ final class NioXnio extends Xnio {
                         objects[2] = creator;
                     } catch (Exception e) {
                         // not available
-                    }
-                    if (! defaultIsPoll && ! jdk9) {
-                        // default is fine for main selectors; we should try to get poll for temp though
-                        if (objects[1] == null) try {
-                            SelectorProvider pollSelectorProvider = Class.forName("sun.nio.ch.PollSelectorProvider", true, NioXnio.class.getClassLoader()).asSubclass(SelectorProvider.class).getConstructor().newInstance();
-                            pollSelectorProvider.openSelector().close();
-                            objects[1] = new DefaultSelectorCreator(provider);
-                        } catch (Exception e) {
-                            // not available
-                        }
                     }
                     if (objects[1] == null) {
                         objects[1] = defaultSelectorCreator;

--- a/pom.xml
+++ b/pom.xml
@@ -62,8 +62,8 @@
         <org.xnio.ssl.new>false</org.xnio.ssl.new>
         <modular.jdk.props></modular.jdk.props>
         <version.org.osgi.core>6.0.0</version.org.osgi.core>
-        <maven.compiler.source>1.8</maven.compiler.source>
-        <maven.compiler.target>1.8</maven.compiler.target>
+        <maven.compiler.source>11</maven.compiler.source>
+        <maven.compiler.target>11</maven.compiler.target>
     </properties>
 
     <dependencyManagement>


### PR DESCRIPTION
https://issues.redhat.com/browse/XNIO-429

Upstream PR: https://github.com/xnio/xnio/pull/321