### PR TITLE
[XNIO-430] Refactoring XNIO SSL to don't use deprecated Pool, Pooled & ByteBufferSlicePool classes

### DIFF
--- a/api/src/main/java/org/xnio/ssl/AbstractAcceptingSslChannel.java
+++ b/api/src/main/java/org/xnio/ssl/AbstractAcceptingSslChannel.java
@@ -23,7 +23,6 @@ import static org.xnio._private.Messages.msg;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
-import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
@@ -36,12 +35,12 @@ import java.util.concurrent.atomic.AtomicReferenceFieldUpdater;
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 
+import org.xnio.ByteBufferPool;
 import org.xnio.ChannelListener;
 import org.xnio.ChannelListeners;
 import org.xnio.Option;
 import org.xnio.OptionMap;
 import org.xnio.Options;
-import org.xnio.Pool;
 import org.xnio.Sequence;
 import org.xnio.SslClientAuthMode;
 import org.xnio.XnioExecutor;
@@ -80,11 +79,11 @@ abstract class AbstractAcceptingSslChannel<C extends ConnectedChannel, S extends
     private final ChannelListener.Setter<AcceptingChannel<C>> closeSetter;
     private final ChannelListener.Setter<AcceptingChannel<C>> acceptSetter;
     protected final boolean startTls;
-    protected final Pool<ByteBuffer> socketBufferPool;
-    protected final Pool<ByteBuffer> applicationBufferPool;
+    protected final ByteBufferPool socketBufferPool;
+    protected final ByteBufferPool applicationBufferPool;
 
 
-    AbstractAcceptingSslChannel(final SSLContext sslContext, final AcceptingChannel<? extends S> tcpServer, final OptionMap optionMap, final Pool<ByteBuffer> socketBufferPool, final Pool<ByteBuffer> applicationBufferPool, final boolean startTls) {
+    AbstractAcceptingSslChannel(final SSLContext sslContext, final AcceptingChannel<? extends S> tcpServer, final OptionMap optionMap, final ByteBufferPool socketBufferPool, final ByteBufferPool applicationBufferPool, final boolean startTls) {
         this.tcpServer = tcpServer;
         this.sslContext = sslContext;
         this.socketBufferPool = socketBufferPool;

--- a/api/src/main/java/org/xnio/ssl/JsseAcceptingSslStreamConnection.java
+++ b/api/src/main/java/org/xnio/ssl/JsseAcceptingSslStreamConnection.java
@@ -19,14 +19,13 @@
 package org.xnio.ssl;
 
 import java.io.IOException;
-import java.nio.ByteBuffer;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
 
+import org.xnio.ByteBufferPool;
 import org.xnio.IoUtils;
 import org.xnio.OptionMap;
-import org.xnio.Pool;
 import org.xnio.StreamConnection;
 import org.xnio.channels.AcceptingChannel;
 
@@ -38,7 +37,7 @@ import org.xnio.channels.AcceptingChannel;
  */
 final class JsseAcceptingSslStreamConnection extends AbstractAcceptingSslChannel<SslConnection, StreamConnection> {
 
-    JsseAcceptingSslStreamConnection(final SSLContext sslContext, final AcceptingChannel<? extends StreamConnection> tcpServer, final OptionMap optionMap, final Pool<ByteBuffer> socketBufferPool, final Pool<ByteBuffer> applicationBufferPool, final boolean startTls) {
+    JsseAcceptingSslStreamConnection(final SSLContext sslContext, final AcceptingChannel<? extends StreamConnection> tcpServer, final OptionMap optionMap, final ByteBufferPool socketBufferPool, final ByteBufferPool applicationBufferPool, final boolean startTls) {
         super(sslContext, tcpServer, optionMap, socketBufferPool, applicationBufferPool, startTls);
     }
 

--- a/api/src/main/java/org/xnio/ssl/JsseSslConnection.java
+++ b/api/src/main/java/org/xnio/ssl/JsseSslConnection.java
@@ -2,7 +2,6 @@ package org.xnio.ssl;
 
 import java.io.IOException;
 import java.net.SocketAddress;
-import java.nio.ByteBuffer;
 import java.util.Set;
 
 import javax.net.ssl.SSLEngine;
@@ -11,7 +10,7 @@ import org.xnio.ChannelListener;
 import org.xnio.ChannelListeners;
 import org.xnio.Option;
 import org.xnio.Options;
-import org.xnio.Pool;
+import org.xnio.ByteBufferPool;
 import org.xnio.SslClientAuthMode;
 import org.xnio.StreamConnection;
 
@@ -25,7 +24,7 @@ public final class JsseSslConnection extends SslConnection {
         this(streamConnection, engine, JsseXnioSsl.bufferPool, JsseXnioSsl.bufferPool);
     }
 
-    JsseSslConnection(final StreamConnection streamConnection, final SSLEngine engine, final Pool<ByteBuffer> socketBufferPool, final Pool<ByteBuffer> applicationBufferPool) {
+    JsseSslConnection(final StreamConnection streamConnection, final SSLEngine engine, final ByteBufferPool socketBufferPool, final ByteBufferPool applicationBufferPool) {
         super(streamConnection.getIoThread());
         this.streamConnection = streamConnection;
         conduit = new JsseStreamConduit(this, engine, streamConnection.getSourceChannel().getConduit(), streamConnection.getSinkChannel().getConduit(), socketBufferPool, applicationBufferPool);

--- a/api/src/main/java/org/xnio/ssl/JsseSslStreamConnection.java
+++ b/api/src/main/java/org/xnio/ssl/JsseSslStreamConnection.java
@@ -19,19 +19,17 @@ package org.xnio.ssl;
 
 import java.io.IOException;
 import java.net.SocketAddress;
-import java.nio.ByteBuffer;
 import java.util.Set;
 import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 
 import javax.net.ssl.SSLEngine;
 import javax.net.ssl.SSLSession;
 
+import org.xnio.ByteBufferPool;
 import org.xnio.ChannelListener;
 import org.xnio.ChannelListeners;
-import org.xnio.Connection;
 import org.xnio.Option;
 import org.xnio.Options;
-import org.xnio.Pool;
 import org.xnio.SslClientAuthMode;
 import org.xnio.StreamConnection;
 import org.xnio.conduits.StreamSinkConduit;
@@ -79,7 +77,7 @@ public final class JsseSslStreamConnection extends SslConnection {
         this(connection, sslEngine, JsseXnioSsl.bufferPool, JsseXnioSsl.bufferPool, startTls);
     }
 
-    JsseSslStreamConnection(StreamConnection connection, SSLEngine sslEngine, final Pool<ByteBuffer> socketBufferPool, final Pool<ByteBuffer> applicationBufferPool, final boolean startTls) {
+    JsseSslStreamConnection(StreamConnection connection, SSLEngine sslEngine, final ByteBufferPool socketBufferPool, final ByteBufferPool applicationBufferPool, final boolean startTls) {
         super(connection.getIoThread());
         this.connection = connection;
         final StreamSinkConduit sinkConduit = connection.getSinkChannel().getConduit();

--- a/api/src/main/java/org/xnio/ssl/JsseXnioSsl.java
+++ b/api/src/main/java/org/xnio/ssl/JsseXnioSsl.java
@@ -26,7 +26,6 @@ import static org.xnio._private.Messages.msg;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.SocketAddress;
-import java.nio.ByteBuffer;
 import java.security.KeyManagementException;
 import java.security.NoSuchAlgorithmException;
 import java.security.NoSuchProviderException;
@@ -35,8 +34,6 @@ import java.util.concurrent.TimeUnit;
 
 import javax.net.ssl.SSLContext;
 import javax.net.ssl.SSLEngine;
-import org.xnio.BufferAllocator;
-import org.xnio.ByteBufferSlicePool;
 import org.xnio.ChannelListener;
 import org.xnio.ChannelListeners;
 import org.xnio.FutureResult;
@@ -45,7 +42,7 @@ import org.xnio.IoUtils;
 import org.xnio.Option;
 import org.xnio.OptionMap;
 import org.xnio.Options;
-import org.xnio.Pool;
+import org.xnio.ByteBufferPool;
 import org.xnio.StreamConnection;
 import org.xnio.Xnio;
 import org.xnio.XnioExecutor;
@@ -66,7 +63,7 @@ import org.xnio.channels.ConnectedStreamChannel;
 public final class JsseXnioSsl extends XnioSsl {
     public static final boolean NEW_IMPL = doPrivileged((PrivilegedAction<Boolean>) () -> Boolean.valueOf(Boolean.parseBoolean(System.getProperty("org.xnio.ssl.new", "false")))).booleanValue();
 
-    static final Pool<ByteBuffer> bufferPool = new ByteBufferSlicePool(BufferAllocator.DIRECT_BYTE_BUFFER_ALLOCATOR, 21 * 1024, 21 * 1024 * 128);
+    static final ByteBufferPool bufferPool = ByteBufferPool.LARGE_DIRECT;
     private final SSLContext sslContext;
 
     /**

--- a/api/src/test/java/org/xnio/ssl/AbstractConnectedSslStreamChannelTest.java
+++ b/api/src/test/java/org/xnio/ssl/AbstractConnectedSslStreamChannelTest.java
@@ -21,14 +21,11 @@ package org.xnio.ssl;
 
 import java.io.IOError;
 import java.io.IOException;
-import java.nio.ByteBuffer;
 
 import org.junit.After;
 import org.junit.Before;
 import org.xnio.AssertReadWrite;
-import org.xnio.BufferAllocator;
-import org.xnio.ByteBufferSlicePool;
-import org.xnio.Pool;
+import org.xnio.ByteBufferPool;
 import org.xnio.channels.AssembledConnectedSslStreamChannel;
 import org.xnio.channels.ConnectedSslStreamChannel;
 import org.xnio.mock.ConduitMock;
@@ -68,8 +65,8 @@ public abstract class AbstractConnectedSslStreamChannelTest extends AbstractSslT
     }
 
     protected ConnectedSslStreamChannel createSslChannel() {
-        final Pool<ByteBuffer> socketBufferPool = new ByteBufferSlicePool(BufferAllocator.BYTE_BUFFER_ALLOCATOR, 17000, 17000 * 16);
-        final Pool<ByteBuffer> applicationBufferPool = new ByteBufferSlicePool(BufferAllocator.BYTE_BUFFER_ALLOCATOR, 17000, 17000 * 16);
+        final ByteBufferPool socketBufferPool = ByteBufferPool.LARGE_HEAP;
+        final ByteBufferPool applicationBufferPool = ByteBufferPool.LARGE_HEAP;
         final SslConnection connection = new JsseSslConnection(connectionMock, engineMock, socketBufferPool, applicationBufferPool);
         try {
             connection.startHandshake();

--- a/api/src/test/java/org/xnio/ssl/AbstractSslConnectionTest.java
+++ b/api/src/test/java/org/xnio/ssl/AbstractSslConnectionTest.java
@@ -21,14 +21,11 @@ package org.xnio.ssl;
 
 import java.io.IOError;
 import java.io.IOException;
-import java.nio.ByteBuffer;
 
 import org.junit.After;
 import org.junit.Before;
 import org.xnio.AssertReadWrite;
-import org.xnio.BufferAllocator;
-import org.xnio.ByteBufferSlicePool;
-import org.xnio.Pool;
+import org.xnio.ByteBufferPool;
 import org.xnio.conduits.StreamSinkConduit;
 import org.xnio.conduits.StreamSourceConduit;
 import org.xnio.mock.ConduitMock;
@@ -68,8 +65,8 @@ public abstract class AbstractSslConnectionTest extends AbstractSslTest {
     }
 
     protected SslConnection createSslConnection() {
-        final Pool<ByteBuffer> socketBufferPool = new ByteBufferSlicePool(BufferAllocator.BYTE_BUFFER_ALLOCATOR, 17000, 17000 * 16);
-        final Pool<ByteBuffer> applicationBufferPool = new ByteBufferSlicePool(BufferAllocator.BYTE_BUFFER_ALLOCATOR, 17000, 17000 * 16);
+        final ByteBufferPool socketBufferPool = ByteBufferPool.LARGE_HEAP;
+        final ByteBufferPool applicationBufferPool = ByteBufferPool.LARGE_HEAP;
         final StreamConnectionMock connectionMock = new StreamConnectionMock(conduitMock);
         final SslConnection connection = new JsseSslConnection(connectionMock, engineMock, socketBufferPool, applicationBufferPool);
         try {

--- a/api/src/test/java/org/xnio/ssl/StartTLSChannelTestCase.java
+++ b/api/src/test/java/org/xnio/ssl/StartTLSChannelTestCase.java
@@ -38,11 +38,9 @@ import javax.net.ssl.SSLEngineResult.HandshakeStatus;
 
 import org.jmock.Expectations;
 import org.junit.Test;
-import org.xnio.BufferAllocator;
-import org.xnio.ByteBufferSlicePool;
+import org.xnio.ByteBufferPool;
 import org.xnio.ChannelListener;
 import org.xnio.Options;
-import org.xnio.Pool;
 import org.xnio.channels.AssembledConnectedSslStreamChannel;
 import org.xnio.channels.ConnectedSslStreamChannel;
 import org.xnio.channels.ConnectedStreamChannel;
@@ -59,8 +57,8 @@ public class StartTLSChannelTestCase extends AbstractConnectedSslStreamChannelTe
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @Override
     protected ConnectedSslStreamChannel createSslChannel() {
-        final Pool<ByteBuffer> socketBufferPool = new ByteBufferSlicePool(BufferAllocator.BYTE_BUFFER_ALLOCATOR, 17000, 17000 * 16);
-        final Pool<ByteBuffer> applicationBufferPool = new ByteBufferSlicePool(BufferAllocator.BYTE_BUFFER_ALLOCATOR, 17000, 17000 * 16);
+        final ByteBufferPool socketBufferPool = ByteBufferPool.LARGE_HEAP;
+        final ByteBufferPool applicationBufferPool = ByteBufferPool.LARGE_HEAP;
         final SslConnection connection = new JsseSslConnection(connectionMock, engineMock, socketBufferPool, applicationBufferPool);
         final ConnectedSslStreamChannel channel = new AssembledConnectedSslStreamChannel(connection, connection.getSourceChannel(), connection.getSinkChannel());
         final ChannelListener readListener = context.mock(ChannelListener.class, "read listener");

--- a/api/src/test/java/org/xnio/ssl/StartTLSConnectionTestCase.java
+++ b/api/src/test/java/org/xnio/ssl/StartTLSConnectionTestCase.java
@@ -38,11 +38,9 @@ import javax.net.ssl.SSLEngineResult.HandshakeStatus;
 
 import org.jmock.Expectations;
 import org.junit.Test;
-import org.xnio.BufferAllocator;
-import org.xnio.ByteBufferSlicePool;
+import org.xnio.ByteBufferPool;
 import org.xnio.ChannelListener;
 import org.xnio.Options;
-import org.xnio.Pool;
 import org.xnio.conduits.ConduitStreamSinkChannel;
 import org.xnio.conduits.ConduitStreamSourceChannel;
 import org.xnio.mock.StreamConnectionMock;
@@ -58,8 +56,8 @@ public class StartTLSConnectionTestCase extends AbstractSslConnectionTest {
     @SuppressWarnings({ "unchecked", "rawtypes" })
     @Override
     protected SslConnection createSslConnection() {
-        final Pool<ByteBuffer> socketBufferPool = new ByteBufferSlicePool(BufferAllocator.BYTE_BUFFER_ALLOCATOR, 17000, 17000 * 16);
-        final Pool<ByteBuffer> applicationBufferPool = new ByteBufferSlicePool(BufferAllocator.BYTE_BUFFER_ALLOCATOR, 17000, 17000 * 16);
+        final ByteBufferPool socketBufferPool = ByteBufferPool.LARGE_HEAP;
+        final ByteBufferPool applicationBufferPool = ByteBufferPool.LARGE_HEAP;
         final StreamConnectionMock connectionMock = new StreamConnectionMock(conduitMock);
         final SslConnection connection = new JsseSslConnection(connectionMock, engineMock, socketBufferPool, applicationBufferPool);
         final ChannelListener readListener = context.mock(ChannelListener.class, "read listener");


### PR DESCRIPTION
https://issues.redhat.com/browse/XNIO-430