### PR TITLE
Revert "[XNIO-385] Ensure that the close method waits until the serve…

### DIFF
--- a/nio-impl/src/main/java/org/xnio/nio/NioTcpServer.java
+++ b/nio-impl/src/main/java/org/xnio/nio/NioTcpServer.java
@@ -258,7 +258,7 @@ final class NioTcpServer extends AbstractNioChannel<NioTcpServer> implements Acc
             channel.close();
         } finally {
             for (NioTcpServerHandle handle : handles) {
-                handle.cancelKey(true);
+                handle.cancelKey(false);
             }
             safeClose(mbeanHandle);
         }


### PR DESCRIPTION
…r key cancellation releases the resources"

This reverts commit 3a738af9bc4b205c0686e32ade96ce2cacdfe84d.
Issue: https://issues.redhat.com/browse/XNIO-435
3.x: https://github.com/xnio/xnio/pull/341
3.9: https://github.com/xnio/xnio/pull/342
3.8: https://github.com/xnio/xnio/pull/343