### PR TITLE
Enabling testing on JDK25

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,7 +41,7 @@ jobs:
       matrix:
         module: [api, nio-impl]
         os: [ubuntu-20.04, windows-latest, macos-latest]
-        jdk: [11, 17, 21]
+        jdk: [11, 17, 21, 25]
         openjdk_impl: [hotspot, openj9]
         exclude:
           - os: macos-latest

--- a/api/src/test/java/org/xnio/XnioTestCase.java
+++ b/api/src/test/java/org/xnio/XnioTestCase.java
@@ -46,6 +46,7 @@ import java.util.ServiceConfigurationError;
 import javax.net.ssl.KeyManagerFactory;
 import javax.net.ssl.TrustManagerFactory;
 
+import org.junit.Assume;
 import org.junit.Test;
 import org.xnio.channels.Channels;
 import org.xnio.mock.ConnectedStreamChannelMock;
@@ -59,9 +60,12 @@ import org.xnio.ssl.XnioSsl;
  */
 public class XnioTestCase {
 
+    private static final int JDK_VERSION;
     static {
         String securityPolicyFile = XnioTestCase.class.getClassLoader().getResource("security.policy").getFile();
         AccessController.doPrivileged(new SetSecurityPolicyAction(securityPolicyFile));
+        String jdkVersion = System.getProperty("java.specification.version", "1.8");
+        JDK_VERSION = "1.8".equals(jdkVersion) ? 8 : Integer.parseInt(jdkVersion);
     }
 
     private static final String DEFAULT_KEY_STORE = "keystore.jks";
@@ -105,6 +109,8 @@ public class XnioTestCase {
 
     @Test
     public void allowBlockingWithSecurity() {
+        Assume.assumeTrue("Skipping on JDK " + JDK_VERSION, JDK_VERSION < 25);
+
         final SecurityManager securityManager = new SecurityManager();
         System.setSecurityManager(securityManager);
         assertTrue(Xnio.isBlockingAllowed());
@@ -365,6 +371,8 @@ public class XnioTestCase {
 
     @Test
     public void propertiesRetrieval() {
+        Assume.assumeTrue("Skipping on JDK " + JDK_VERSION, JDK_VERSION < 25);
+
         final Xnio xnio = Xnio.getInstance();
         assertNull(xnio.getProperty("xnio.test.prop"));
         assertEquals("foo", xnio.getProperty("xnio.test.prop", "foo"));
@@ -382,6 +390,8 @@ public class XnioTestCase {
 
     @Test
     public void illegalPropertiesRetrieval() {
+        Assume.assumeTrue("Skipping on JDK " + JDK_VERSION, JDK_VERSION < 25);
+
         System.setSecurityManager(null);
         final Xnio xnio = Xnio.getInstance();
         

--- a/pom.xml
+++ b/pom.xml
@@ -178,11 +178,31 @@
         <profile>
             <id>jdk18</id>
             <activation>
-                <jdk>[18,)</jdk>
+                <jdk>[17,24)</jdk>
             </activation>
             <properties>
                 <modular.jdk.props>-Djava.security.manager=allow</modular.jdk.props>
             </properties>
+        </profile>
+        <profile>
+            <id>jdk23</id>
+            <activation>
+                <jdk>[23,)</jdk>
+            </activation>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-compiler-plugin</artifactId>
+                        <configuration>
+                            <compilerArgs combine.children="append">
+                                <!-- SE 23+ requires explicit config to turn on annotation processing -->
+                                <arg>-proc:full</arg>
+                            </compilerArgs>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
 


### PR DESCRIPTION
 - Turning on compiler annotation processing on JDK23+
 - Disabling security manager properties setting on JDK25+
 - Disabling tests using security manager framework on JDK25+
 - Adding JDK25 to CI pipeline